### PR TITLE
Allow new linux-intel kernel from meta-intel BSP

### DIFF
--- a/meta-refkit/conf/distro/include/refkit-supported-recipes.txt
+++ b/meta-refkit/conf/distro/include/refkit-supported-recipes.txt
@@ -185,6 +185,7 @@ libwebp@core
 libxml2@core
 libxslt@core
 linux-firmware@core
+linux-intel@intel
 linux-libc-headers@core
 linux-yocto@core
 lowpan-tools@networking-layer


### PR DESCRIPTION
Force preferred kernel version to 4.9 in order to better support
recent hardware like Joule.

Signed-off-by: Jussi Laako <jussi.laako@linux.intel.com>