### PR TITLE
Computer vision profile test image configuration + better handling of web cameras to the main profile

### DIFF
--- a/meta-refkit/classes/refkit-image.bbclass
+++ b/meta-refkit/classes/refkit-image.bbclass
@@ -222,6 +222,14 @@ FEATURE_PACKAGES_tools-interactive = "packagegroup-tools-interactive bash"
 # All our platforms support it, so this can be unconditional.
 FEATURE_PACKAGES_tools-debug_append = " valgrind"
 
+# Computer vision profile has package groups. The packages in
+# packagegroup-computervision are used in both "production" and
+# "development" configurations, but packages in
+# packagegroup-computervision-test are used only in "development"
+# configuration.
+FEATURE_PACKAGES_computervision = "packagegroup-computervision"
+FEATURE_PACKAGES_computervision-test = "packagegroup-computervision-test"
+
 # We could make bash the login shell for interactive accounts as shown
 # below, but that would have to be done also in the os-core and thus
 # tools-interactive would have to be set in all swupd images.

--- a/meta-refkit/conf/distro/include/refkit-development.inc
+++ b/meta-refkit/conf/distro/include/refkit-development.inc
@@ -17,3 +17,4 @@ REFKIT_EXTRA_MOTD () {
 # Everything ready, avoid initial sanity check.
 REFKIT_IMAGE_BUILD_MODE_SELECTED = "1"
 
+REFKIT_IMAGE_COMPUTERVISION_EXTRA_FEATURES_append = " computervision-test"

--- a/meta-refkit/conf/distro/include/refkit-supported-recipes.txt
+++ b/meta-refkit/conf/distro/include/refkit-supported-recipes.txt
@@ -173,6 +173,7 @@ libunistring@core
 libunwind@core
 liburcu@core
 libusb1@core
+libva-intel-driver@intel
 libva@core
 libvorbis@core
 libwebp@core

--- a/meta-refkit/conf/distro/include/refkit-supported-recipes.txt
+++ b/meta-refkit/conf/distro/include/refkit-supported-recipes.txt
@@ -86,10 +86,12 @@ gcc-runtime@core
 gcc@core
 gdb@core
 gdbm@core
+gdk-pixbuf@core
 gettext@core
 gflags@openembedded-layer
 git@core
 glib-2.0@core
+glib-networking@core
 glibc-locale@core
 glibc-mtrace@core
 glibc@core
@@ -104,6 +106,7 @@ gptfdisk@core
 grep@core
 gstreamer1.0-plugins-bad@core
 gstreamer1.0-plugins-base@core
+gstreamer1.0-plugins-good@core
 gstreamer1.0-vaapi@core
 gstreamer1.0@core
 gzip@core
@@ -151,6 +154,7 @@ libgcc@core
 libgcrypt@core
 libgpg-error@core
 libgphoto2@openembedded-layer
+libgudev@core
 libical@core
 libidn@core
 libjpeg-turbo@core
@@ -167,6 +171,7 @@ libpthread-stubs@core
 libsamplerate0@core
 libsndfile1@core
 libsocketcan@openembedded-layer
+libsoup-2.4@core
 libtheora@core
 libtool@core
 libunistring@core
@@ -239,6 +244,8 @@ shared-mime-info@core
 shm-util@iotqa
 smack-userspace@security-smack
 soletta@soletta
+speex@core
+speexdsp@core
 spi-minnowmax-board@quark-bsp
 spi-quark-board@quark-bsp
 sqlite3@core
@@ -249,6 +256,7 @@ systemd-boot@core
 systemd-compat-units@core
 systemd-watchdog@quark-bsp
 systemd@core
+taglib@core
 tbb@openembedded-layer
 tcp-smack-test@security-smack
 tiff@core

--- a/meta-refkit/recipes-computervision/packagegroups/packagegroup-computervision-test.bb
+++ b/meta-refkit/recipes-computervision/packagegroups/packagegroup-computervision-test.bb
@@ -1,0 +1,9 @@
+SUMMARY = "Components for computer vision profile testing and interactive use"
+LICENSE = "MIT"
+
+inherit packagegroup
+
+RDEPENDS_${PN} = " \
+    opencv-samples \
+    python3-opencv \
+"

--- a/meta-refkit/recipes-computervision/packagegroups/packagegroup-computervision.bb
+++ b/meta-refkit/recipes-computervision/packagegroups/packagegroup-computervision.bb
@@ -6,4 +6,5 @@ inherit packagegroup
 RDEPENDS_${PN} = " \
     opencv \
     gstreamer1.0-vaapi \
+    libva-intel-driver \
 "

--- a/meta-refkit/recipes-computervision/packagegroups/packagegroup-computervision.bb
+++ b/meta-refkit/recipes-computervision/packagegroups/packagegroup-computervision.bb
@@ -1,0 +1,9 @@
+SUMMARY = "Components for computer vision profile"
+LICENSE = "MIT"
+
+inherit packagegroup
+
+RDEPENDS_${PN} = " \
+    opencv \
+    gstreamer1.0-vaapi \
+"

--- a/meta-refkit/recipes-computervision/packagegroups/packagegroup-computervision.bb
+++ b/meta-refkit/recipes-computervision/packagegroups/packagegroup-computervision.bb
@@ -6,5 +6,6 @@ inherit packagegroup
 RDEPENDS_${PN} = " \
     opencv \
     gstreamer1.0-vaapi \
+    gstreamer1.0-plugins-good \
     libva-intel-driver \
 "

--- a/meta-refkit/recipes-image/images/refkit-image-computervision.bb
+++ b/meta-refkit/recipes-image/images/refkit-image-computervision.bb
@@ -6,7 +6,10 @@ REFKIT_IMAGE_COMPUTERVISION_EXTRA_INSTALL ?= "${REFKIT_IMAGE_INSTALL_COMMON}"
 REFKIT_IMAGE_EXTRA_FEATURES += "${REFKIT_IMAGE_COMPUTERVISION_EXTRA_FEATURES}"
 REFKIT_IMAGE_EXTRA_INSTALL += "${REFKIT_IMAGE_COMPUTERVISION_EXTRA_INSTALL}"
 
-REFKIT_IMAGE_COMPUTERVISION_EXTRA_INSTALL_append = " opencv gstreamer1.0-vaapi"
+REFKIT_IMAGE_COMPUTERVISION_EXTRA_FEATURES += "computervision"
+
+# Feature "computervision-test" is included if "development" version of the
+# image is compiled.
 
 # Example for customization in local.conf when building
 # refkit-image-computervision.bb:
@@ -15,4 +18,3 @@ REFKIT_IMAGE_COMPUTERVISION_EXTRA_INSTALL_append = " opencv gstreamer1.0-vaapi"
 # REFKIT_IMAGE_COMPUTERVISION_EXTRA_FEATURES_append = "dev-pkgs"
 
 inherit refkit-image
-


### PR DESCRIPTION
Add test configuration to computer vision profile. If the image is build in "development" mode, add interactive test and development packages. The initial test content is bit limited, but more is planned.

Also add libva-intel-driver and gstreamer-plugins-good to the computer vision images in both production and development mode. This enhances webcam support (by adding v4l2src element among other things) and enables HW acceleration of libva operations using Intel GPU backend.