### PR TITLE
Enable RMC

### DIFF
--- a/meta-refkit/classes/image-dsk.bbclass
+++ b/meta-refkit/classes/image-dsk.bbclass
@@ -33,6 +33,7 @@ IMAGE_NAME_SUFFIX = ""
 
 do_uefiapp[depends] += " \
                          systemd-boot:do_deploy \
+                         rmc-db:do_deploy \
                          virtual/kernel:do_deploy \
                          initramfs-framework:do_populate_sysroot \
                          intel-microcode:do_deploy \
@@ -209,6 +210,11 @@ export PART_%(pnum)d_FS=%(filesystem)s
     with open(d.expand('${B}/emmc-partitions-data'), 'w') as emmc_part_data:
         emmc_part_data.write(partition_data)
     shutil.copyfile(d.expand('${B}/emmc-partitions-data'), d.expand('${DEPLOYDIR}/emmc-partitions-data'))
+
+    # The RMC database is deployed unconditionally but not read if the BIOS is in SecureBoot mode.
+    # XXX: However, the check for SecureBoot is not present. The bug is tracked in
+    # https://bugzilla.yoctoproject.org/show_bug.cgi?id=11030
+    shutil.copyfile(d.expand('${DEPLOY_DIR_IMAGE}/rmc.db'), d.expand('${DEPLOYDIR}/rmc.db'))
 }
 
 DEPLOYDIR = "${WORKDIR}/uefiapp-${PN}"

--- a/meta-refkit/classes/refkit-image.bbclass
+++ b/meta-refkit/classes/refkit-image.bbclass
@@ -340,12 +340,7 @@ ima_evm_sign_rootfs_prepend () {
 # for that machine.
 APPEND_append = "${@bb.utils.contains('IMAGE_FEATURES', 'smack', '', ' security=none', d)}"
 
-# FIXME: Get rid of the Intel(r) 500 series vs intel-corei7-64 inconsistency
-# settings for current BXT platforms.
-APPEND_append_intel-corei7-64 = " console=ttyS2,115200 video=efifb maxcpus=4 noxsave reboot=efi kmemleak=off"
-SERIAL_CONSOLE_intel-corei7-64 = "115200 ttyS2"
-# We get console=ttyS0,115200 from meta-intel/conf/machine/intel-corei7-64.conf and
-# need to get rid of it.
+# Use what RMC gives, not the defaults in meta-intel machine configs
 APPEND_remove_intel-corei7-64 = "console=ttyS0,115200"
 
 # In addition, when Smack is disabled in the image but enabled in the


### PR DESCRIPTION
This PR enables Runtime Machine Configuration (RMC) feature from meta-intel. It helps to apply board specific settings (e.g., kernel cmdline) runtime. In particular, we get the serial console information for the boards we're running.