### PR TITLE
openssh_%.bbappend: fix incorrect iptables dependency.

### DIFF
--- a/meta-refkit/recipes-security/openssh/openssh_%.bbappend
+++ b/meta-refkit/recipes-security/openssh/openssh_%.bbappend
@@ -1,6 +1,6 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
-RDEPENDS_${PN} += "iptables"
+RDEPENDS_${PN}-sshd += "iptables"
 
 SRC_URI_append = "\
     file://${PN}-ipv4.conf \


### PR DESCRIPTION
The openssh base package is empty. Having the iptables runtime
dependency there is useless, as the base package never gets
installed. Move the dependency to the proper -sshd subpackage.

Signed-off-by: Krisztian Litkey <krisztian.litkey@intel.com>