### PR TITLE
Add librealsense to computer vision profile.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,3 +25,6 @@
 [submodule "meta-security-isafw"]
 	path = meta-security-isafw
 	url = https://github.com/01org/meta-security-isafw.git
+[submodule "meta-intel-realsense"]
+	path = meta-intel-realsense
+	url = https://github.com/IntelRealSense/meta-intel-realsense.git

--- a/meta-refkit/conf/bblayers.conf.sample
+++ b/meta-refkit/conf/bblayers.conf.sample
@@ -14,6 +14,7 @@ REFKIT_LAYERS = " \
   ##OEROOT##/../meta-iot-web \
   ##OEROOT##/../meta-iotqa \
   ##OEROOT##/../meta-security-isafw \
+  ##OEROOT##/../meta-intel-realsense \
   "
 
 # REFKIT_LAYERS += "##OEROOT##/../meta-openembedded/meta-efl"

--- a/meta-refkit/conf/distro/include/refkit-supported-recipes.txt
+++ b/meta-refkit/conf/distro/include/refkit-supported-recipes.txt
@@ -168,6 +168,7 @@ libpciaccess@core
 libpcre@core
 libpng@core
 libpthread-stubs@core
+librealsense@librealsense
 libsamplerate0@core
 libsndfile1@core
 libsocketcan@openembedded-layer

--- a/meta-refkit/recipes-computervision/librealsense/files/0001-examples-control-building-of-the-graphical-examples.patch
+++ b/meta-refkit/recipes-computervision/librealsense/files/0001-examples-control-building-of-the-graphical-examples.patch
@@ -1,0 +1,249 @@
+From 7b6134844a57470421ed1552dcc6ce053e6d70a1 Mon Sep 17 00:00:00 2001
+From: Ismo Puustinen <ismo.puustinen@intel.com>
+Date: Fri, 10 Feb 2017 15:46:23 +0200
+Subject: [PATCH] examples: control building of the graphical examples.
+
+The graphical examples require a graphical environment, while the
+standard examples can be run in a headless system. Separate the two with
+a compile switch. If you want to disable building of the graphical
+examples, use
+
+    -DBUILD_GRAPHICAL_EXAMPLES=off
+
+in the cmake command line. By default the graphical examples are built
+if BUILD_EXAMPLES is selected, so the default behavior does not change.
+
+Upstream-status: Submitted [https://github.com/IntelRealSense/librealsense/pull/435]
+
+---
+ examples/CMakeLists.txt | 173 +++++++++++++++++++++++++++---------------------
+ 1 file changed, 96 insertions(+), 77 deletions(-)
+
+diff --git a/examples/CMakeLists.txt b/examples/CMakeLists.txt
+index 57009d5..3887b93 100644
+--- a/examples/CMakeLists.txt
++++ b/examples/CMakeLists.txt
+@@ -10,6 +10,10 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS 1)
+ # View the makefile commands during build
+ #set(CMAKE_VERBOSE_MAKEFILE on)
+ 
++# This parameter is meant for disabling graphical examples when building for
++# headless targets.
++option(BUILD_GRAPHICAL_EXAMPLES "Build graphical examples." ON)
++
+ include(CheckCXXCompilerFlag)
+ CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
+ CHECK_CXX_COMPILER_FLAG("-std=c++0x" COMPILER_SUPPORTS_CXX0X)
+@@ -21,73 +25,55 @@ else()
+     message(STATUS "The compiler ${CMAKE_CXX_COMPILER} has no C++11 support. Please use a different C++ compiler.")
+ endif()
+ 
+-find_package(OpenGL REQUIRED)
+-set(DEPENDENCIES realsense ${OPENGL_LIBRARIES})
+-
+-if(WIN32)
+-    add_subdirectory(third_party/glfw)
+-    list(APPEND DEPENDENCIES glfw3)
++if(BUILD_GRAPHICAL_EXAMPLES)
++    find_package(OpenGL REQUIRED)
++    set(DEPENDENCIES realsense ${OPENGL_LIBRARIES})
++
++    if(WIN32)
++        add_subdirectory(third_party/glfw)
++        list(APPEND DEPENDENCIES glfw3)
++    else()
++        # Find glfw header
++        find_path(GLFW_INCLUDE_DIR NAMES GLFW/glfw3.h
++            PATHS /usr/X11R6/include
++                  /usr/include/X11
++                  /opt/graphics/OpenGL/include
++                  /opt/graphics/OpenGL/contrib/libglfw
++                  /usr/local/include
++                  /usr/include/GL
++                  /usr/include
++        )
++        # Find glfw library
++        find_library(GLFW_LIBRARIES NAMES glfw glfw3
++                PATHS /usr/lib64
++                      /usr/lib
++                      /usr/lib/${CMAKE_LIBRARY_ARCHITECTURE}
++                      /usr/local/lib64
++                      /usr/local/lib
++                      /usr/local/lib/${CMAKE_LIBRARY_ARCHITECTURE}
++                      /usr/X11R6/lib
++        )
++        list(APPEND DEPENDENCIES m ${GLFW_LIBRARIES} ${LIBUSB1_LIBRARIES})
++        include_directories(${GLFW_INCLUDE_DIR})
++    endif()
+ else()
+-    # Find glfw header
+-    find_path(GLFW_INCLUDE_DIR NAMES GLFW/glfw3.h
+-        PATHS /usr/X11R6/include
+-              /usr/include/X11
+-              /opt/graphics/OpenGL/include
+-              /opt/graphics/OpenGL/contrib/libglfw
+-              /usr/local/include
+-              /usr/include/GL
+-              /usr/include
+-    )
+-    # Find glfw library
+-    find_library(GLFW_LIBRARIES NAMES glfw glfw3
+-            PATHS /usr/lib64
+-                  /usr/lib
+-                  /usr/lib/${CMAKE_LIBRARY_ARCHITECTURE}
+-                  /usr/local/lib64
+-                  /usr/local/lib
+-                  /usr/local/lib/${CMAKE_LIBRARY_ARCHITECTURE}
+-                  /usr/X11R6/lib
+-    )
+-    list(APPEND DEPENDENCIES m ${GLFW_LIBRARIES} ${LIBUSB1_LIBRARIES})
+-    include_directories(${GLFW_INCLUDE_DIR})
++    set(DEPENDENCIES realsense)
++    if(NOT WIN32)
++        list(APPEND DEPENDENCIES m ${LIBUSB1_LIBRARIES})
++    endif()
+ endif()
+ 
+-# C Tutorials
++# C/C++ tutorials and examples
++
+ add_executable(c-tutorial-1-depth c-tutorial-1-depth.c)
+ target_link_libraries(c-tutorial-1-depth ${DEPENDENCIES})
+ 
+-add_executable(c-tutorial-2-streams c-tutorial-2-streams.c)
+-target_link_libraries(c-tutorial-2-streams ${DEPENDENCIES})
+-
+-add_executable(c-tutorial-3-pointcloud c-tutorial-3-pointcloud.c)
+-target_link_libraries(c-tutorial-3-pointcloud ${DEPENDENCIES})
+-
+-# C++ Tutorials
+ add_executable(cpp-tutorial-1-depth cpp-tutorial-1-depth.cpp)
+ target_link_libraries(cpp-tutorial-1-depth ${DEPENDENCIES})
+ 
+-add_executable(cpp-tutorial-2-streams cpp-tutorial-2-streams.cpp)
+-target_link_libraries(cpp-tutorial-2-streams ${DEPENDENCIES})
+-
+-add_executable(cpp-tutorial-3-pointcloud cpp-tutorial-3-pointcloud.cpp)
+-target_link_libraries(cpp-tutorial-3-pointcloud ${DEPENDENCIES})
+-
+-# Examples
+-add_executable(cpp-alignimages cpp-alignimages.cpp)
+-target_link_libraries(cpp-alignimages ${DEPENDENCIES})
+-
+ add_executable(cpp-callback cpp-callback.cpp)
+ target_link_libraries(cpp-callback ${DEPENDENCIES})
+ 
+-add_executable(cpp-callback-2 cpp-callback-2.cpp)
+-target_link_libraries(cpp-callback-2 ${DEPENDENCIES})
+-
+-add_executable(cpp-capture cpp-capture.cpp)
+-target_link_libraries(cpp-capture ${DEPENDENCIES})
+-
+-add_executable(cpp-config-ui cpp-config-ui.cpp)
+-target_link_libraries(cpp-config-ui ${DEPENDENCIES})
+-
+ add_executable(cpp-enumerate-devices cpp-enumerate-devices.cpp)
+ target_link_libraries(cpp-enumerate-devices ${DEPENDENCIES})
+ 
+@@ -97,43 +83,76 @@ target_link_libraries(cpp-headless ${DEPENDENCIES})
+ add_executable(cpp-motion-module cpp-motion-module.cpp)
+ target_link_libraries(cpp-motion-module ${DEPENDENCIES})
+ 
+-add_executable(cpp-multicam cpp-multicam.cpp)
+-target_link_libraries(cpp-multicam ${DEPENDENCIES})
++if(BUILD_GRAPHICAL_EXAMPLES)
++    add_executable(c-tutorial-2-streams c-tutorial-2-streams.c)
++    target_link_libraries(c-tutorial-2-streams ${DEPENDENCIES})
++
++    add_executable(c-tutorial-3-pointcloud c-tutorial-3-pointcloud.c)
++    target_link_libraries(c-tutorial-3-pointcloud ${DEPENDENCIES})
++
++    add_executable(cpp-tutorial-2-streams cpp-tutorial-2-streams.cpp)
++    target_link_libraries(cpp-tutorial-2-streams ${DEPENDENCIES})
+ 
+-add_executable(cpp-pointcloud cpp-pointcloud.cpp)
+-target_link_libraries(cpp-pointcloud ${DEPENDENCIES})
++    add_executable(cpp-tutorial-3-pointcloud cpp-tutorial-3-pointcloud.cpp)
++    target_link_libraries(cpp-tutorial-3-pointcloud ${DEPENDENCIES})
+ 
+-add_executable(cpp-restart cpp-restart.cpp)
+-target_link_libraries(cpp-restart ${DEPENDENCIES})
++    add_executable(cpp-alignimages cpp-alignimages.cpp)
++    target_link_libraries(cpp-alignimages ${DEPENDENCIES})
+ 
+-add_executable(cpp-stride cpp-stride.cpp)
+-target_link_libraries(cpp-stride ${DEPENDENCIES})
++    add_executable(cpp-callback-2 cpp-callback-2.cpp)
++    target_link_libraries(cpp-callback-2 ${DEPENDENCIES})
++
++    add_executable(cpp-capture cpp-capture.cpp)
++    target_link_libraries(cpp-capture ${DEPENDENCIES})
++
++    add_executable(cpp-config-ui cpp-config-ui.cpp)
++    target_link_libraries(cpp-config-ui ${DEPENDENCIES})
++
++    add_executable(cpp-multicam cpp-multicam.cpp)
++    target_link_libraries(cpp-multicam ${DEPENDENCIES})
++
++    add_executable(cpp-pointcloud cpp-pointcloud.cpp)
++    target_link_libraries(cpp-pointcloud ${DEPENDENCIES})
++
++    add_executable(cpp-restart cpp-restart.cpp)
++    target_link_libraries(cpp-restart ${DEPENDENCIES})
++
++    add_executable(cpp-stride cpp-stride.cpp)
++    target_link_libraries(cpp-stride ${DEPENDENCIES})
++
++    install(
++        TARGETS
++        c-tutorial-2-streams
++        c-tutorial-3-pointcloud
++
++        cpp-tutorial-2-streams
++        cpp-tutorial-3-pointcloud
++
++        cpp-alignimages
++        cpp-callback-2
++        cpp-capture
++        cpp-config-ui
++        cpp-multicam
++        cpp-pointcloud
++        cpp-restart
++        cpp-stride
++
++        RUNTIME DESTINATION
++        ${CMAKE_INSTALL_BINDIR}
++    )
++endif()
+ 
+ install(
+     TARGETS
+     c-tutorial-1-depth
+-    c-tutorial-2-streams
+-    c-tutorial-3-pointcloud
+ 
+     cpp-tutorial-1-depth
+-    cpp-tutorial-2-streams
+-    cpp-tutorial-3-pointcloud
+ 
+-    cpp-alignimages
+     cpp-callback
+-    cpp-callback-2
+-    cpp-capture
+-    cpp-config-ui
+     cpp-enumerate-devices
+     cpp-headless
+     cpp-motion-module
+-    cpp-multicam
+-    cpp-pointcloud
+-    cpp-restart
+-    cpp-stride
+ 
+     RUNTIME DESTINATION
+     ${CMAKE_INSTALL_BINDIR}
+ )
+-
+-
+-- 
+2.9.3
+

--- a/meta-refkit/recipes-computervision/librealsense/files/0001-scripts-removed-bashisms.patch
+++ b/meta-refkit/recipes-computervision/librealsense/files/0001-scripts-removed-bashisms.patch
@@ -1,0 +1,58 @@
+From e23c5f6c42f020a1356e870776869becafcf67c4 Mon Sep 17 00:00:00 2001
+From: Ismo Puustinen <ismo.puustinen@intel.com>
+Date: Thu, 9 Feb 2017 13:19:26 +0200
+Subject: [PATCH] scripts: removed bashisms.
+
+The udev configuration files might be used on systems which don't have
+bash installed. Convert the scripts to use "any shell" instead of bash.
+Also fix a few issues found by shellcheck.
+
+Upstream-status: Submitted [https://github.com/IntelRealSense/librealsense/pull/434]
+
+---
+ config/usb-R200-in      | 10 +++++-----
+ config/usb-R200-in_udev |  4 ++--
+ 2 files changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/config/usb-R200-in b/config/usb-R200-in
+index 6eed625..7e88886 100644
+--- a/config/usb-R200-in
++++ b/config/usb-R200-in
+@@ -1,12 +1,12 @@
+-#!/bin/bash
++#!/bin/sh
+ lockdir="/dswork.lock"
+ if mkdir "$lockdir" 
+     then 
+         # Successfully acquired lock
+         for i in $(ls /sys/bus/usb/drivers/uvcvideo/|grep :) ; do
+-             echo $i >/sys/bus/usb/drivers/uvcvideo/unbind
+-            echo $i >/sys/bus/usb/drivers/uvcvideo/bind
+-            echo "Reseting" $i
++            echo "$i" >/sys/bus/usb/drivers/uvcvideo/unbind
++            echo "$i" >/sys/bus/usb/drivers/uvcvideo/bind
++            echo "Reseting" "$i"
+         done    
+ 
+         sleep 2
+@@ -14,4 +14,4 @@ if mkdir "$lockdir"
+     else
+         # Cannot acquire lock. Aborting.
+         exit 0
+-fi
+\ No newline at end of file
++fi
+diff --git a/config/usb-R200-in_udev b/config/usb-R200-in_udev
+index 093d1b1..299d30e 100644
+--- a/config/usb-R200-in_udev
++++ b/config/usb-R200-in_udev
+@@ -1,3 +1,3 @@
+-#!/bin/bash
++#!/bin/sh
+ 
+-/usr/local/bin/usb-R200-in &
+\ No newline at end of file
++/usr/local/bin/usb-R200-in &
+-- 
+2.9.3
+

--- a/meta-refkit/recipes-computervision/librealsense/librealsense_%.bbappend
+++ b/meta-refkit/recipes-computervision/librealsense/librealsense_%.bbappend
@@ -3,14 +3,15 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 DEPENDS = "libusb1 ${@bb.utils.contains('DISTRO_FEATURES', 'x11 opengl', 'libpng libglu glfw', '', d)}"
 
 EXTRA_OECMAKE = " \
-       -DBUILD_SHARED_LIBS:BOOL=ON -DBUILD_UNIT_TESTS:BOOL=OFF \
-       -DBUILD_EXAMPLES:BOOL=${@bb.utils.contains('DISTRO_FEATURES', 'x11 opengl', 'ON', 'OFF', d)} \
+       -DBUILD_SHARED_LIBS:BOOL=ON -DBUILD_UNIT_TESTS:BOOL=OFF -DBUILD_EXAMPLES:BOOL=ON \
+       -DBUILD_GRAPHICAL_EXAMPLES:BOOL=${@bb.utils.contains('DISTRO_FEATURES', 'x11 opengl', 'ON', 'OFF', d)} \
 "
  
-PACKAGES = "${PN} ${PN}-dbg ${PN}-dev ${@bb.utils.contains('DISTRO_FEATURES', 'x11 opengl', '${PN}-examples ${PN}-graphical-examples', '', d)}"
+PACKAGES = "${PN} ${PN}-dbg ${PN}-dev ${PN}-examples ${@bb.utils.contains('DISTRO_FEATURES', 'x11 opengl', '${PN}-graphical-examples', '', d)}"
 
 SRC_URI_append = " \
     file://0001-scripts-removed-bashisms.patch \
+    file://0001-examples-control-building-of-the-graphical-examples.patch \
 "
 
 RDEPENDS_${PN}_remove = "bash"

--- a/meta-refkit/recipes-computervision/librealsense/librealsense_%.bbappend
+++ b/meta-refkit/recipes-computervision/librealsense/librealsense_%.bbappend
@@ -1,3 +1,5 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
 DEPENDS = "libusb1 ${@bb.utils.contains('DISTRO_FEATURES', 'x11 opengl', 'libpng libglu glfw', '', d)}"
 
 EXTRA_OECMAKE = " \
@@ -7,3 +9,8 @@ EXTRA_OECMAKE = " \
  
 PACKAGES = "${PN} ${PN}-dbg ${PN}-dev ${@bb.utils.contains('DISTRO_FEATURES', 'x11 opengl', '${PN}-examples ${PN}-graphical-examples', '', d)}"
 
+SRC_URI_append = " \
+    file://0001-scripts-removed-bashisms.patch \
+"
+
+RDEPENDS_${PN}_remove = "bash"

--- a/meta-refkit/recipes-computervision/librealsense/librealsense_%.bbappend
+++ b/meta-refkit/recipes-computervision/librealsense/librealsense_%.bbappend
@@ -1,0 +1,9 @@
+DEPENDS = "libusb1 ${@bb.utils.contains('DISTRO_FEATURES', 'x11 opengl', 'libpng libglu glfw', '', d)}"
+
+EXTRA_OECMAKE = " \
+       -DBUILD_SHARED_LIBS:BOOL=ON -DBUILD_UNIT_TESTS:BOOL=OFF \
+       -DBUILD_EXAMPLES:BOOL=${@bb.utils.contains('DISTRO_FEATURES', 'x11 opengl', 'ON', 'OFF', d)} \
+"
+ 
+PACKAGES = "${PN} ${PN}-dbg ${PN}-dev ${@bb.utils.contains('DISTRO_FEATURES', 'x11 opengl', '${PN}-examples ${PN}-graphical-examples', '', d)}"
+

--- a/meta-refkit/recipes-computervision/packagegroups/packagegroup-computervision-test.bb
+++ b/meta-refkit/recipes-computervision/packagegroups/packagegroup-computervision-test.bb
@@ -6,4 +6,5 @@ inherit packagegroup
 RDEPENDS_${PN} = " \
     opencv-samples \
     python3-opencv \
+    librealsense-examples \
 "

--- a/meta-refkit/recipes-computervision/packagegroups/packagegroup-computervision.bb
+++ b/meta-refkit/recipes-computervision/packagegroups/packagegroup-computervision.bb
@@ -8,4 +8,5 @@ RDEPENDS_${PN} = " \
     gstreamer1.0-vaapi \
     gstreamer1.0-plugins-good \
     libva-intel-driver \
+    librealsense \
 "


### PR DESCRIPTION
Add `meta-intel-realsense` layer. Fix librealsense recipe so that it compiles without X11 support. Patch librealsense itself so that we can drop bash runtime dependency and have non-graphical examples for testing and trying out librealsense. The local patches have been submitted to upstream, so in the future we might drop the three patches that change librealsense behavior.