### PR TITLE
Pulseaudio: enable the use of pulseaudio packages

### DIFF
--- a/meta-refkit/conf/distro/include/refkit-group
+++ b/meta-refkit/conf/distro/include/refkit-group
@@ -17,6 +17,7 @@ messagebus:x:998:
 netdev:x:999:
 nobody:x:65534:
 nogroup:x:65533:
+pulse:x:1122:
 restful:x:991:
 rfkill:x:50:
 root:x:0:

--- a/meta-refkit/conf/distro/include/refkit-passwd
+++ b/meta-refkit/conf/distro/include/refkit-passwd
@@ -4,6 +4,7 @@ foodine-pythontest:x:1002:1002::/home/foodine-pythontest:/sbin/nologin
 iodine-nodetest:x:1001:1001::/home/iodine-nodetest:/sbin/nologin
 messagebus:x:998:998::/var/lib/dbus:/bin/false
 nobody:x:65534:65534:nobody:/nonexistent:/bin/sh
+pulse:x:1122:1122::/var/run/pulse:/sbin/nologin
 restful:x:991:991::/home/restful:/bin/false
 root:x:0:0:root:/home/root:/bin/sh
 sshd:x:992:992::/var/run/sshd:/bin/false

--- a/meta-refkit/conf/distro/include/refkit-supported-recipes.txt
+++ b/meta-refkit/conf/distro/include/refkit-supported-recipes.txt
@@ -31,6 +31,7 @@
 
 acl@core
 alsa-lib@core
+alsa-plugins@core
 alsa-state@core
 alsa-utils@core
 appfw-test-app@iotqa
@@ -221,6 +222,7 @@ ppp@core
 procps@core
 protobuf@openembedded-layer
 ptest-runner@core
+pulseaudio@core
 python-dbus@core
 python-nose@core
 python-numpy@core
@@ -239,6 +241,7 @@ rmc-db@intel
 rmc@intel
 rsync@core
 run-postinsts@core
+sbc@core
 sed@core
 shadow-securetty@core
 shadow@core

--- a/meta-refkit/conf/distro/refkit.conf
+++ b/meta-refkit/conf/distro/refkit.conf
@@ -61,11 +61,15 @@ PACKAGECONFIG_pn-python3-pygobject ?= ""
 # pango, a graphical text rendering library, is not needed by us.
 PACKAGECONFIG_remove_pn-gstreamer1.0-plugins-base = "pango"
 
+PACKAGECONFIG_remove_pn-alsa_plugins = "speexdsp"
+
+PACKAGECONFIG_remove_pn-pulseaudio = "avahi"
+
 MAINTAINER = "Mikko Ylinen <mikko.ylinen@linux.intel.com>"
 
 TARGET_VENDOR = "-refkit"
 
-REFKIT_DEFAULT_DISTRO_FEATURES = "systemd bluez5 pam"
+REFKIT_DEFAULT_DISTRO_FEATURES = "systemd bluez5 pam pulseaudio"
 REFKIT_DEFAULT_EXTRA_RDEPENDS ??= ""
 REFKIT_DEFAULT_EXTRA_RRECOMMENDS ??= ""
 
@@ -190,7 +194,7 @@ QEMU_TARGETS ?= "arm i386 x86_64"
 
 VIRTUAL-RUNTIME_init_manager = "systemd"
 VIRTUAL-RUNTIME_initscripts = ""
-DISTRO_FEATURES_BACKFILL_CONSIDERED = "sysvinit pulseaudio"
+DISTRO_FEATURES_BACKFILL_CONSIDERED = "sysvinit"
 
 require conf/distro/include/no-static-libs.inc
 require conf/distro/include/refkit_security_flags.inc

--- a/meta-refkit/recipes-core/base-passwd/files/group.master
+++ b/meta-refkit/recipes-core/base-passwd/files/group.master
@@ -1,4 +1,5 @@
 root:*:0:
+audio:*:29:
 rfkill:*:50:
 nobody:*:65533:
 nogroup:*:65534:

--- a/meta-refkit/recipes-multimedia/pulseaudio/pulseaudio_%.bbappend
+++ b/meta-refkit/recipes-multimedia/pulseaudio/pulseaudio_%.bbappend
@@ -1,0 +1,3 @@
+DEPENDS_remove = "speexdsp gconf"
+DEPENDS += "libsamplerate0"
+EXTRA_OECONF += " --without-speex --disable-gconf --enable-samplerate"


### PR DESCRIPTION
Add pulseaudio to distro features and supported
recipes. Create also audio group and pulse user.
This commit doesn't include any pulseaudio packages
to the images.

Signed-off-by: Jaska Uimonen <jaska.uimonen@intel.com>