### PR TITLE
meta-iotqa: Ignore Minnowboard boot error

### DIFF
--- a/meta-iotqa/lib/oeqa/runtime/sanity/baseos.py
+++ b/meta-iotqa/lib/oeqa/runtime/sanity/baseos.py
@@ -113,7 +113,8 @@ class BaseOsTest(oeRuntimeTest):
             "Direct firmware load for iwlwifi-8000C",
             "ACPI Error: Could not enable RealTimeClock event",
             "hci_intel: probe of INT33E1:00 failed with error -2",
-            "Error changing net interface name 'usb0' to"
+            "Error changing net interface name 'usb0' to",
+            "*ERROR* dp aux hw did not signal timeout"
             ]
         self.longMessage = True
         cmd = "journalctl -ab"


### PR DESCRIPTION
Add '\*ERROR\* dp aux hw did not signal timeout' to list of ignored
errors. This error happens randomly under 5% of the time and doesn't
seem to cause any additional errors in other tests. Tried to reproduce
the error with an image that it happened with but couldn't get it with 25
flash/test cycles. This error also doesn't seem to be easily fixed. So ignore this
error as it will cause tests to fail randomly.

Signed-off-by: Simo Kuusela <simo.kuusela@intel.com>