### PR TITLE
Add bluetooth audio packages to gateway profile

### DIFF
--- a/meta-iotqa/conf/test/refkit-image-gateway.manifest
+++ b/meta-iotqa/conf/test/refkit-image-gateway.manifest
@@ -1,2 +1,3 @@
 # Tests for gateway profile
 oeqa.runtime.sanity.apprt_nodejs
+oeqa.runtime.sanity.pulseaudio

--- a/meta-iotqa/lib/oeqa/runtime/sanity/pulseaudio.py
+++ b/meta-iotqa/lib/oeqa/runtime/sanity/pulseaudio.py
@@ -1,0 +1,11 @@
+from oeqa.oetest import oeRuntimeTest
+from oeqa.utils.decorators import tag
+
+class PulseaudioTest(oeRuntimeTest):
+
+    '''Check pulseaudio existence'''
+    def test_pulseaudio_exists(self):
+
+        (status, output) = self.target.run('ls /usr/bin/pulseaudio')
+
+        self.assertEqual(output, "/usr/bin/pulseaudio", msg="Error messages: pulseaudio not found")

--- a/meta-refkit/classes/refkit-image.bbclass
+++ b/meta-refkit/classes/refkit-image.bbclass
@@ -44,6 +44,7 @@ REFKIT_IMAGE_PKG_FEATURES = " \
     tools-debug \
     tools-develop \
     alsa \
+    bluetooth-audio \
 "
 
 REFKIT_IMAGE_PKG_FEATURES += " \
@@ -209,6 +210,8 @@ FEATURE_PACKAGES_nodejs-runtime-tools = "packagegroup-nodejs-runtime-tools"
 FEATURE_PACKAGES_python-runtime = "packagegroup-python-runtime"
 
 FEATURE_PACKAGES_alsa = "alsa-utils alsa-state"
+
+FEATURE_PACKAGES_bluetooth-audio = "packagegroup-bluetooth-audio"
 
 # git is not essential for compiling software, but include it anyway
 # because it is the most common source code management tool.

--- a/meta-refkit/recipes-core/packagegroups/packagegroup-bluetooth-audio.bb
+++ b/meta-refkit/recipes-core/packagegroups/packagegroup-bluetooth-audio.bb
@@ -1,0 +1,16 @@
+SUMMARY = "IoT Reference OS Kit Bluetooth Audio"
+LICENSE = "MIT"
+
+inherit packagegroup
+
+RDEPENDS_${PN} = " \
+    pulseaudio \
+    pulseaudio-server \
+    pulseaudio-misc \
+    pulseaudio-module-loopback \
+    pulseaudio-module-bluetooth-discover \
+    pulseaudio-module-bluetooth-policy \
+    pulseaudio-module-bluez5-device \
+    pulseaudio-module-bluez5-discover \
+    sbc \
+"

--- a/meta-refkit/recipes-image/images/refkit-image-gateway.bb
+++ b/meta-refkit/recipes-image/images/refkit-image-gateway.bb
@@ -6,7 +6,7 @@ REFKIT_IMAGE_GATEWAY_EXTRA_INSTALL ?= "${REFKIT_IMAGE_INSTALL_COMMON}"
 REFKIT_IMAGE_EXTRA_FEATURES += "${REFKIT_IMAGE_GATEWAY_EXTRA_FEATURES}"
 REFKIT_IMAGE_EXTRA_INSTALL += "${REFKIT_IMAGE_GATEWAY_EXTRA_INSTALL}"
 
-REFKIT_IMAGE_GATEWAY_EXTRA_FEATURES_append = " iotivity nodejs-runtime"
+REFKIT_IMAGE_GATEWAY_EXTRA_FEATURES_append = " iotivity nodejs-runtime bluetooth-audio"
 
 # Example for customization in local.conf when building
 # refkit-image-gateway.bb:


### PR DESCRIPTION
Add pulseaudio and its bluetooth related modules
to gateway profile. Includes also a simple test to
check the existence of the daemon.

Signed-off-by: Jaska Uimonen <jaska.uimonen@intel.com>