### PR TITLE
meta-iotqa: Remove some ignored errors

### DIFF
--- a/meta-iotqa/lib/oeqa/runtime/sanity/baseos.py
+++ b/meta-iotqa/lib/oeqa/runtime/sanity/baseos.py
@@ -94,13 +94,6 @@ class BaseOsTest(oeRuntimeTest):
         ''' check systemd boot journal error'''
         known_issues_list = [
             "GPT: Use GNU Parted to correct GPT errors",
-            # IOTOS-1575 [Edison] wpa_supplicant error during system booting
-            "Failed to open config file '/etc/wpa_supplicant/wpa_supplicant-wlan0.conf'",
-            # ignore kernel errors
-            "^\w{3,} \d{,2} \d{2}:\d{2}:\d{2} \S+ kernel:",
-            # IOTOS-1691 Ethernet relevant errors at system startup
-            "Error changing net interface name \S+ to \S+: Device or resource busy",
-            "open error Permission denied for /var/lib/connman/ethernet_\S+_cable/data",
             # Error from Beaglebone Black USB keyboard or ethernet emulation
             "0003:8086:BEEF.0001",
             # Harmless error
@@ -108,7 +101,6 @@ class BaseOsTest(oeRuntimeTest):
             # Errors from bad Intel(r) 500 series support
             "ACPI Error: Could not enable PowerButton event",
             "button: probe of LNXPWRBN:00 failed with error -22",
-            "probe of LNXPWRBN:00 failed",
             "Direct firmware load for i915/bxt_dmc_ver1_07.bin failed",
             "Direct firmware load for iwlwifi-8000C",
             "ACPI Error: Could not enable RealTimeClock event",


### PR DESCRIPTION
"Error changing net interface name..." and "probe of LNXPWRBN:00 failed"
are duplicates. Rest of them don't seem to be relevant anymore.

Signed-off-by: Simo Kuusela <simo.kuusela@intel.com>