### PR TITLE
meta-iotqa: Add REST API server checking and stability tests

### DIFF
--- a/meta-iotqa/conf/test/restapichecklocal.manifest
+++ b/meta-iotqa/conf/test/restapichecklocal.manifest
@@ -1,0 +1,1 @@
+oeqa.runtime.nodejs.rest_check_local

--- a/meta-iotqa/conf/test/restapicheckremote.manifest
+++ b/meta-iotqa/conf/test/restapicheckremote.manifest
@@ -1,0 +1,2 @@
+oeqa.runtime.nodejs.rest_one_ocf_server_remote
+oeqa.runtime.nodejs.rest_multi_ocf_servers_remote

--- a/meta-iotqa/conf/test/stability.manifest
+++ b/meta-iotqa/conf/test/stability.manifest
@@ -1,0 +1,1 @@
+oeqa.runtime.nodejs.rest_stability

--- a/meta-iotqa/lib/oeqa/runtime/nodejs/copy_necessary_files.py
+++ b/meta-iotqa/lib/oeqa/runtime/nodejs/copy_necessary_files.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+
+import os
+
+def copy_smarthome_demo_ocf_server(ip, to_dir = '/home/root'):
+	'''
+	Copy SmartHome-Demo/ocf-servers directory to target IP.
+	'''
+	files_dir = os.path.join(os.path.dirname(__file__), 'files')
+	target_sh_demo_dir = '{prefix}/SmartHome-Demo/ocf-servers/js-servers'.format(prefix = to_dir)
+
+	os.system('ssh root@{ip} "test -d {d1} || mkdir -pv {d2}"'.format(
+						ip = ip, d1 = target_sh_demo_dir, d2 = target_sh_demo_dir))
+	os.chdir(files_dir)
+	os.system('scp -r ocfservers/*.js root@{ip}:{target_dir}/'.format(ip = ip, target_dir = target_sh_demo_dir))
+
+def copy_rest_api_check_local_js(ip, to_dir = '/home/root'):
+	'''
+	Copy local directory restapilocal to to_dir on target devices.
+	'''
+	files_dir = os.path.join(os.path.dirname(__file__), 'files')
+	restapilocal_dir = os.path.join(files_dir, 'restapilocal')
+	mocha_dir = os.path.join(restapilocal_dir, 'node_modules', 'mocha')
+
+	if not os.path.exists(mocha_dir):
+		os.chdir(restapilocal_dir)
+		os.system('npm install')
+
+	os.chdir(files_dir)
+	os.system('scp -r restapilocal root@{ip}:{to}/SmartHome-Demo'.format(ip = ip, to = to_dir))

--- a/meta-iotqa/lib/oeqa/runtime/nodejs/files/ocfservers/gas.js
+++ b/meta-iotqa/lib/oeqa/runtime/nodejs/files/ocfservers/gas.js
@@ -1,0 +1,158 @@
+// Copyright 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var device = require('iotivity-node'),
+    debuglog = require('util').debuglog('gas'),
+    gasResource,
+    sensorPin,
+    gasDensity = 0,
+    resourceTypeName = 'oic.r.sensor.carbondioxide',
+    resourceInterfaceName = '/a/gas',
+    notifyObserversTimeoutId,
+    exitId,
+    observerCount = 0,
+    hasUpdate = false,
+    gasDetected = false;
+
+// Setup Gas sensor pin.
+function setupHardware() {
+}
+
+// This function construct the payload and returns when
+// the GET request received from the client.
+function getProperties() {
+    // Simulate real sensor behavior.
+    gasDetected = !gasDetected;
+    hasUpdate = true;
+
+    // Format the properties.
+    var properties = {
+        rt: resourceTypeName,
+        id: 'gasSensor',
+        value: gasDetected
+    };
+
+    return properties;
+}
+
+// Set up the notification loop
+function notifyObservers() {
+    var properties = getProperties();
+
+    notifyObserversTimeoutId = null;
+    if (hasUpdate) {
+        gasResource.properties = properties;
+        hasUpdate = false;
+
+        debuglog('Send the response: ', gasDetected);
+        gasResource.notify().catch(
+            function(error) {
+                debuglog('Failed to notify observers with error: ', error);
+                if (error.observers.length === 0) {
+                    observerCount = 0;
+                    if (notifyObserversTimeoutId) {
+                        clearTimeout(notifyObserversTimeoutId);
+                        notifyObserversTimeoutId = null;
+                    }
+                }
+            });
+    }
+
+    // After all our clients are complete, we don't care about any
+    // more requests to notify.
+    if (observerCount > 0) {
+        notifyObserversTimeoutId = setTimeout(notifyObservers, 2000);
+    }
+}
+
+// Event handlers for the registered resource.
+function retrieveHandler(request) {
+    gasResource.properties = getProperties();
+    request.respond(gasResource).catch(handleError);
+
+    if ('observe' in request) {
+        hasUpdate = true;
+        observerCount += request.observe ? 1 : -1;
+        if (!notifyObserversTimeoutId && observerCount > 0)
+            setTimeout(notifyObservers, 200);
+    }
+}
+
+device.device = Object.assign(device.device, {
+    name: 'Smart Home Gas Sensor',
+    coreSpecVersion: 'core.1.1.0',
+    dataModels: ['res.1.1.0']
+});
+
+function handleError(error) {
+    debuglog('Failed to send response with error: ', error);
+}
+
+device.platform = Object.assign(device.platform, {
+    manufacturerName: 'Intel',
+    manufactureDate: new Date('Fri Oct 30 10:04:17 (EET) 2015'),
+    platformVersion: '1.1.0',
+    firmwareVersion: '0.0.1'
+});
+
+if (device.device.uuid) {
+    // Setup Gas sensor pin.
+    setupHardware();
+
+    debuglog('Create Gas resource.');
+
+    // Register Gas resource
+    device.server.register({
+        resourcePath: resourceInterfaceName,
+        resourceTypes: [resourceTypeName],
+        interfaces: ['oic.if.baseline'],
+        discoverable: true,
+        observable: true,
+        properties: getProperties()
+    }).then(
+        function(resource) {
+            debuglog('register() resource successful');
+            gasResource = resource;
+
+            // Add event handlers for each supported request type
+            resource.onretrieve(retrieveHandler);
+        },
+        function(error) {
+            debuglog('register() resource failed with: ', error);
+        });
+}
+
+// Cleanup when interrupted
+function exitHandler() {
+    debuglog('Delete Gas Resource.');
+
+    if (exitId)
+        return;
+
+    // Unregister resource.
+    gasResource.unregister().then(
+        function() {
+            debuglog('unregister() resource successful');
+        },
+        function(error) {
+            debuglog('unregister() resource failed with: ', error);
+        });
+
+    // Exit
+    exitId = setTimeout(function() { process.exit(0); }, 1000);
+}
+
+// Exit gracefully
+process.on('SIGINT', exitHandler);
+process.on('SIGTERM', exitHandler);

--- a/meta-iotqa/lib/oeqa/runtime/nodejs/files/ocfservers/led.js
+++ b/meta-iotqa/lib/oeqa/runtime/nodejs/files/ocfservers/led.js
@@ -1,0 +1,153 @@
+// Copyright 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var device = require('iotivity-node'),
+    debuglog = require('util').debuglog('led'),
+    ledResource,
+    sensorPin,
+    exitId,
+    observerCount = 0,
+    sensorState = false,
+    resourceTypeName = 'oic.r.led',
+    resourceInterfaceName = '/a/led';
+
+// Setup LED sensor pin.
+function setupHardware() {
+}
+
+// This function parce the incoming Resource properties
+// and change the sensor state.
+function updateProperties(properties) {
+    sensorState = properties.value;
+
+    debuglog('Update received. value: ', sensorState);
+}
+
+// This function construct the payload and returns when
+// the GET request received from the client.
+function getProperties() {
+    // Format the payload.
+    var properties = {
+        rt: resourceTypeName,
+        id: 'led',
+        value: sensorState
+    };
+
+    debuglog('Send the response. value: ', sensorState);
+    return properties;
+}
+
+// Set up the notification loop
+function notifyObservers(request) {
+    ledResource.properties = getProperties();
+
+    ledResource.notify().then(
+        function() {
+            debuglog('Successfully notified observers.');
+        },
+        function(error) {
+            debuglog('Notify failed with error: ', error);
+        });
+}
+
+// Event handlers for the registered resource.
+function retrieveHandler(request) {
+    ledResource.properties = getProperties();
+    request.respond(ledResource).catch(handleError);
+
+    if ('observe' in request) {
+        observerCount += request.observe ? 1 : -1;
+        if (observerCount > 0)
+            setTimeout(notifyObservers, 200);
+    }
+}
+
+function updateHandler(request) {
+    updateProperties(request.data);
+    ledResource.properties = getProperties();
+
+    request.respond(ledResource).catch(handleError);
+    if (observerCount > 0)
+        setTimeout(notifyObservers, 200);
+}
+
+device.device = Object.assign(device.device, {
+    name: 'Smart Home LED',
+    coreSpecVersion: 'core.1.1.0',
+    dataModels: ['res.1.1.0']
+});
+
+function handleError(error) {
+    debuglog('LED: Failed to send response with error: ', error);
+}
+
+device.platform = Object.assign(device.platform, {
+    manufacturerName: 'Intel',
+    manufactureDate: new Date('Fri Oct 30 10:04:17 (EET) 2015'),
+    platformVersion: '1.1.0',
+    firmwareVersion: '0.0.1'
+});
+
+// Enable presence
+if (device.device.uuid) {
+    // Setup LED pin.
+    setupHardware();
+
+    debuglog('Create LED resource.');
+
+    // Register LED resource
+    device.server.register({
+        resourcePath: resourceInterfaceName,
+        resourceTypes: [resourceTypeName],
+        interfaces: ['oic.if.baseline'],
+        discoverable: true,
+        observable: true,
+        properties: getProperties()
+    }).then(
+        function(resource) {
+            debuglog('register() resource successful');
+            ledResource = resource;
+
+            // Add event handlers for each supported request type
+            resource.onretrieve(retrieveHandler);
+            resource.onupdate(updateHandler);
+        },
+        function(error) {
+            debuglog('register() resource failed with: ', error);
+        });
+}
+
+// Cleanup when interrupted
+function exitHandler() {
+    debuglog('Delete LED Resource.');
+
+    if (exitId)
+        return;
+
+    // Unregister resource.
+    ledResource.unregister().then(
+        function() {
+            debuglog('unregister() resource successful');
+        },
+        function(error) {
+            debuglog('unregister() resource failed with: ', error);
+        });
+
+    // Exit
+    exitId = setTimeout(function() { process.exit(0); }, 1000);
+}
+
+// Exit gracefully
+process.on('SIGINT', exitHandler);
+process.on('SIGTERM', exitHandler);

--- a/meta-iotqa/lib/oeqa/runtime/nodejs/files/restapilocal/test/common.js
+++ b/meta-iotqa/lib/oeqa/runtime/nodejs/files/restapilocal/test/common.js
@@ -1,0 +1,51 @@
+var http = require('http');
+
+var ocfServerDir = '/home/root/SmartHome-Demo/ocf-servers/js-servers';
+var waitChildProcess = 2000,
+    testCaseTimeout = 20000,
+    requestTimeout = 5000,
+    multiReqNum = 2;
+
+var options_t = {
+    host: '127.0.0.1',
+    port: 8000,
+    path: '',
+    method: 'GET',
+    headers: {
+        'Accept': 'text/json'
+    }
+};
+
+var options_d = Object.assign({}, options_t);
+options_d.path = '/api/oic/d';
+
+var options_p = Object.assign({}, options_t);
+options_p.path = '/api/oic/p';
+
+var options_res = Object.assign({}, options_t);
+options_res.path = '/api/oic/res';
+
+function sendRestRequests(options, n) {
+    for (var i = 0; i < n; i++) {
+        // console.log('request time ', i);
+        var req = http.request(options, function(res){
+            res.setEncoding('utf8');
+            res.on('data', function (data) {
+                // console.log('in before ', data);
+            });
+        });
+        req.end();
+    }
+}
+
+exports.ocfServerDir = ocfServerDir;
+exports.waitChildProcess = waitChildProcess;
+exports.testCaseTimeout = testCaseTimeout;
+exports.requestTimeout = requestTimeout;
+exports.multiReqNum = multiReqNum;
+
+exports.options_d = options_d;
+exports.options_p = options_p
+exports.options_res = options_res;
+
+exports.sendRestRequests = sendRestRequests;

--- a/meta-iotqa/lib/oeqa/runtime/nodejs/files/restapilocal/test/test_multiple_ocf_servers_locally.js
+++ b/meta-iotqa/lib/oeqa/runtime/nodejs/files/restapilocal/test/test_multiple_ocf_servers_locally.js
@@ -1,0 +1,180 @@
+var http = require('http'),
+    assert = require('assert'),
+    spawn = require('child_process').spawn;
+
+var common = require('./common');
+var ocfServerDir = common.ocfServerDir,
+    waitChildProcess = common.waitChildProcess,
+    testCaseTimeout = common.testCaseTimeout,
+    requestTimeout = common.requestTimeout,
+    multiReqNum = common.multiReqNum,
+    options_d = common.options_d,
+    options_p = common.options_p,
+    options_res = common.options_res,
+    sendRestRequests = common.sendRestRequests;
+
+var childLed,
+    childGas;
+
+function sendRestRequests(options, n) {
+    for (var i = 0; i < n; i++) {
+        // console.log('request time ', i);
+        var req = http.request(options, function(res){
+            res.setEncoding('utf8');
+            res.on('data', function (data) {
+                // console.log('in before ', data);
+            });
+        });
+        req.end();
+    }
+}
+
+describe('Multiple OCF server case', function() {
+    before(function() {
+        // console.log('launch led.js...');
+        childLed = spawn('node', ['led.js'], {
+            cwd: ocfServerDir,
+            env: process.env
+        });
+        // console.log('launch gas.js...');
+        childGas = spawn('node', ['gas.js'], {
+            cwd: ocfServerDir,
+            env: process.env
+        });
+    });
+    
+    describe('Multiple devices should be found', function() {
+        this.timeout(testCaseTimeout);
+
+        before(function() {
+            setTimeout(function() {
+                sendRestRequests(options_d, multiReqNum);
+            }, waitChildProcess);
+        });
+
+        it('multi_ocf_devices_local', function(done) {
+            setTimeout(function(){
+
+                // send HTTP request
+                var req = http.request(options_d, function(res) {
+                    res.setEncoding('utf8');
+                    res.on('data', function (data) {
+                        // console.log('in test ', data);                        
+                        var devLedFound = false,
+                            devGasFound = false,
+                            iterTimes = 0;
+                        var devices = JSON.parse(data);
+
+                        assert.equal(2, devices.length);
+                        devices.forEach(function(device, index, arrary) {
+                            if (device['n'] === 'Smart Home LED') {
+                                devLedFound = true;
+                            }
+                            if (device['n'] === 'Smart Home Gas Sensor') {
+                                devGasFound = true;
+                            }
+                            iterTimes++;
+                            if (iterTimes === arrary.length) {
+                                assert(devLedFound);
+                                assert(devGasFound);
+                                done();
+                            }
+                        });
+                    });
+                });
+                req.end();
+            }, requestTimeout);
+        })
+    });
+
+    describe('Multiple platforms should be found', function() {
+        this.timeout(testCaseTimeout);
+
+        before(function() {
+            setTimeout(function() {
+                sendRestRequests(options_p, multiReqNum);
+            }, waitChildProcess);
+        });
+
+        it('multi_ocf_platforms_local', function(done) {
+            setTimeout(function(){
+
+                // send HTTP request
+                var req = http.request(options_p, function(res) {
+                    res.setEncoding('utf8');
+
+                    res.on('data', function (data) {
+                        // console.log('in test', data);
+                        var iterTimes = 0;
+                        var platforms = JSON.parse(data);
+
+                        assert.equal(2, platforms.length);
+                        platforms.forEach(function(platform, index, array) {
+                            assert.equal('Intel', platform['mnmn']);
+                            iterTimes++;
+                            if (iterTimes === array.length) {
+                                done();
+                            }
+                        });
+                    });
+                });
+                req.end();
+            }, requestTimeout);
+        });
+    });
+
+    describe('Multiple resources should be found', function() {
+        this.timeout(testCaseTimeout);
+
+        before(function() {
+            setTimeout(function() {
+                sendRestRequests(options_res, multiReqNum);
+            }, waitChildProcess);
+        });
+
+        it('multi_ocf_resources_local', function(done) {
+            setTimeout(function(){
+
+                // send HTTP request
+                var req = http.request(options_res, function(res) {
+                    res.setEncoding('utf8');
+                    res.on('data', function (data) {
+                        // console.log('in test ', data);
+                        var ledHrefNum = 0,
+                            gasHrefNum = 0,
+                            iterTimes = 0;
+                        var ledRt, gasRt;
+                        var resources = JSON.parse(data);
+
+                        resources.forEach(function (resource, index, arrary) {
+                            if (resource.links[0]['href'] === '/a/led') {
+                                ledHrefNum++;
+                                ledRt = resource.links[0]['rt'];
+                            }
+                            if (resource.links[0]['href'] === '/a/gas') {
+                                gasHrefNum++;
+                                gasRt = resource.links[0]['rt'];
+                            }
+                            iterTimes++;
+                            if (iterTimes === arrary.length) {
+                                assert.equal(1, ledHrefNum);
+                                assert.equal('oic.r.led', ledRt);
+                                assert.equal(1, gasHrefNum);
+                                assert.equal('oic.r.sensor.carbondioxide', gasRt);
+                                done();
+                            }               
+                        });
+                    });
+                });
+                req.end();
+            }, requestTimeout);
+        });
+    });
+
+    after(function() {
+        // console.log('killing led.js...');
+        childLed.kill('SIGINT');
+        // console.log('killing gas.js...');
+        childGas.kill('SIGINT');
+    });
+});

--- a/meta-iotqa/lib/oeqa/runtime/nodejs/files/restapilocal/test/test_one_ocf_server_locally.js
+++ b/meta-iotqa/lib/oeqa/runtime/nodejs/files/restapilocal/test/test_one_ocf_server_locally.js
@@ -1,0 +1,125 @@
+var http = require('http'),
+    assert = require('assert'),
+    spawn = require('child_process').spawn;
+
+var common = require('./common');
+var ocfServerDir = common.ocfServerDir,
+    waitChildProcess = common.waitChildProcess,
+    testCaseTimeout = common.testCaseTimeout,
+    requestTimeout = common.requestTimeout,
+    multiReqNum = common.multiReqNum,
+    options_d = common.options_d,
+    options_p = common.options_p,
+    options_res = common.options_res,
+    sendRestRequests = common.sendRestRequests; 
+
+var child;
+
+describe('One OCF server case', function() {
+    before(function() {
+        // console.log('launch led.js...');
+        child = spawn('node', ['led.js'], {
+            cwd: ocfServerDir,
+            env: process.env
+        });        
+    });
+
+    describe('Only one LED device should be found', function() {
+        this.timeout(testCaseTimeout);
+
+        before(function() {
+            setTimeout(function() {
+                sendRestRequests(options_d, multiReqNum);
+            }, waitChildProcess);
+        });
+
+        it('unique_ocf_device_local', function(done) {
+            setTimeout(function() {
+                // send HTTP request
+                var req = http.request(options_d, function(res) {
+                    res.setEncoding('utf8');
+                    res.on('data', function (data) {
+                        // console.log('in test ', data);
+                        var devices = JSON.parse(data);
+                        assert.equal(1, devices.length);
+                        assert.equal('Smart Home LED', devices[0]['n']);
+                        done();                    
+                    });
+                });
+                req.end();            
+            }, requestTimeout);
+        });
+    });
+
+    describe('Only one LED platform should be found', function() {
+        this.timeout(testCaseTimeout);
+
+        before(function() {
+            setTimeout(function() {
+                sendRestRequests(options_p, multiReqNum);
+            }, waitChildProcess);
+        });
+
+        it('unique_ocf_platform_local', function(done) {
+            setTimeout(function() {
+                // send HTTP request
+                var req = http.request(options_p, function(res) {
+                    res.setEncoding('utf8');
+                    res.on('data', function (data) {
+                        // console.log('in test ', data);
+                        var platforms = JSON.parse(data);                    
+                        assert.equal(1, platforms.length);
+                        assert.equal('Intel', platforms[0]['mnmn']);
+                        done();
+                    });
+                });
+                req.end();
+            }, requestTimeout);
+        });
+    });
+
+    describe('Only one LED resource should be found', function() {
+        this.timeout(testCaseTimeout);
+
+        before(function() {
+            setTimeout(function() {
+                sendRestRequests(options_res, multiReqNum);
+            }, waitChildProcess);
+        });
+
+        it('unique_ocf_resource_local', function(done) {
+            setTimeout(function() {
+                // send HTTP request
+                var req = http.request(options_res, function(res) {
+                    res.setEncoding('utf8');
+                    res.on('data', function (data) {
+                        // console.log('in test ', data);
+                        var ledHrefNum = 0,
+                            iterTimes = 0;
+                        var ledRt;
+                        var resources = JSON.parse(data);
+
+                        resources.forEach(function (resource, key, array) {                        
+                            if (resource.links[0]['href'] === '/a/led') {
+                                ledHrefNum++;
+                                ledRt = resource.links[0]['rt'];
+                            }
+                            iterTimes++;
+                            if (iterTimes === array.length ) {
+                                assert.equal(1, ledHrefNum);
+                                assert.equal('oic.r.led', ledRt);
+                                done();                            
+                            }
+                        });
+                    });
+                });
+                req.end();            
+            }, requestTimeout);
+        });
+    });
+
+    after(function(){
+        // console.log('killing led.js...');
+        child.kill('SIGINT');
+    })
+});

--- a/meta-iotqa/lib/oeqa/runtime/nodejs/iot_config.py
+++ b/meta-iotqa/lib/oeqa/runtime/nodejs/iot_config.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+
+import os
+import requests
+
+class IoTTargetConfiguration:
+	'''
+	IoT Target configuration
+	'''
+
+	def __init__(self):
+		self.restapilocal = 'restapilocal'
+		self.home_dir = '/home/root'
+		self.sh_demo_dir = os.path.join(self.home_dir, 'SmartHome-Demo')
+		self.js_test_dir = os.path.join(self.sh_demo_dir, self.restapilocal)
+		self.ocf_dir = os.path.join(self.sh_demo_dir, 'ocf-servers', 'js-servers')
+
+		self.cleanup = True
+		self.need_copy_files = True
+		self.use_systemd_rest_api = True
+		self.do_open_port = True
+		self.do_close_port = True
+
+		self.url_oic_d = 'http://{ip}:8000/api/oic/d'
+		self.url_oic_p = 'http://{ip}:8000/api/oic/p'
+		self.url_oic_res = 'http://{ip}:8000/api/oic/res'
+		self.wait_launch_ocf_server = 10
+		self.wait_kill_ocf_server = 4
+
+		self.session = requests.Session()
+		self.session.trust_env = False
+
+	def launch_iot_rest_api_server(self, target):
+		'''
+		Launch the iot-rest-api-server service via systemctl.
+		'''
+		if self.use_systemd_rest_api:
+			target.run('systemctl start iot-rest-api-server')
+
+	def open_ports_for_rest_api(self, target):
+		'''
+		Open 5683/5684/8000 port for iot-rest-api-server.
+		'''
+		if self.do_open_port:
+			target.run('iptables -A INPUT -p tcp -m tcp --dport 8000 -j ACCEPT')
+			target.run('iptables -A INPUT -p udp -m udp --dport 5683 -j ACCEPT')
+			target.run('iptables -A INPUT -p udp -m udp --dport 5684 -j ACCEPT')
+			target.run('ip6tables -w -A INPUT -s fe80::/10 -p udp -m udp --dport 5683 -j ACCEPT')
+			target.run('ip6tables -w -A INPUT -s fe80::/10 -p udp -m udp --dport 5684 -j ACCEPT')
+
+	def close_ports_for_cleanup(self, target):
+		'''
+		Close 5683/5684/8000 port after tests.
+		'''
+		if self.do_close_port:
+			target.run('iptables -D INPUT -p tcp -m tcp --dport 8000 -j ACCEPT')
+			target.run('iptables -D INPUT -p udp -m udp --dport 5683 -j ACCEPT')
+			target.run('iptables -D INPUT -p udp -m udp --dport 5684 -j ACCEPT')
+			target.run('ip6tables -w -D INPUT -s fe80::/10 -p udp -m udp --dport 5683 -j ACCEPT')
+			target.run('ip6tables -w -D INPUT -s fe80::/10 -p udp -m udp --dport 5684 -j ACCEPT')
+
+	def prepare_test(self, target):
+		'''
+		Prepare work before the test.
+		'''
+		self.launch_iot_rest_api_server(target)
+		self.open_ports_for_rest_api(target)
+
+	def send_multi_requests(self, ip, n):
+		'''
+		Send several requests
+		'''
+		for i in range(n):
+			self.session.get(self.url_oic_d.format(ip = ip))
+			self.session.get(self.url_oic_p.format(ip = ip))
+			self.session.get(self.url_oic_res.format(ip = ip))
+
+	def launch_ocf_server(self, ip, ocf_server_file):
+		'''
+		Launch an OCF server.
+		'''
+		print('\nLaunch the OCF server {ocf_server} on the target device...'.format(
+			ocf_server = ocf_server_file))
+		launch_ocf_server_cmd = 'ssh root@{ip} '\
+								'"export NODE_PATH=/usr/lib/node_modules/;'\
+								'cd {ocf_dir};node {ocf_server} &" &'.format(
+									ip = ip,
+									ocf_dir = self.ocf_dir,
+									ocf_server = ocf_server_file)
+		os.system(launch_ocf_server_cmd)
+
+	def kill_ocf_server(self, target, pattern, signal = '-INT'):
+		'''
+		Kill process that contains the pattern in the command line.
+		'''
+		ps_ocf_svr_cmd = 'ps | grep -v grep | grep {p}'.format(p = pattern)
+		(status, output) = target.run(ps_ocf_svr_cmd)
+		print('\n' + output)
+		ps = output.strip().split('\n')
+
+		for p in ps:
+			if not p:
+				continue
+			pid = p.strip().split()[0]
+			kill_ocf_svr_cmd = 'kill {sig} {pid}'.format(sig = signal, pid = pid)
+			print(kill_ocf_svr_cmd)
+			target.run(kill_ocf_svr_cmd)
+
+	def clean_up(self, target):
+		'''
+		Clean up work
+		'''
+		if self.cleanup:
+			target.run('rm -fr {d}'.format(d = self.sh_demo_dir))
+
+		if self.do_close_port:
+			self.close_ports_for_cleanup(target)

--- a/meta-iotqa/lib/oeqa/runtime/nodejs/rest_check_local.py
+++ b/meta-iotqa/lib/oeqa/runtime/nodejs/rest_check_local.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import time
+import json
+
+from oeqa.oetest import oeRuntimeTest
+
+sys.path.append(os.path.dirname(__file__))
+import copy_necessary_files
+import iot_config
+
+class RestApiCheckLocalTest(oeRuntimeTest):
+
+    iot_target = iot_config.IoTTargetConfiguration()
+
+    @classmethod
+    def setUpClass(cls):
+        '''
+        Copy necessary files to target.
+        '''
+        if cls.iot_target.need_copy_files:
+            copy_necessary_files.copy_smarthome_demo_ocf_server(cls.tc.target.ip)
+            copy_necessary_files.copy_rest_api_check_local_js(cls.tc.target.ip)
+
+        cls.iot_target.prepare_test(cls.tc.target)
+
+    def test_restapi_locally(self):
+        '''
+        Send REST request again and find only one OCF device.
+        '''
+        test_cmd = 'export NODE_PATH=/usr/lib/node_modules/;'\
+                   'cd {js_test_dir};./node_modules/mocha/bin/mocha -R json'.format(
+                        js_test_dir = self.iot_target.js_test_dir)
+        (status, output) = self.target.run(test_cmd)
+
+        self.parse_test_results(output)
+
+    def parse_test_results(self, output):
+        '''
+        Parse the test results from mocha JSON format.
+        '''
+        results = json.loads(output.strip())
+
+        template = '%s - runtest.py - RESULTS - Testcase %s: %s\n'
+        results_data = []
+        for failure in results.get('failures'):
+            result = template % (time.strftime('%H:%M:%S', time.gmtime()),
+                        failure.get('title'), 'FAILED')
+            results_data.append(result)
+        for block in results.get('pending'):
+            result = template % (time.strftime('%H:%M:%S', time.gmtime()),
+                        block.get('title'), 'BLOCKED')
+            results_data.append(result)
+        for passe in results.get('passes'):
+            result = template % (time.strftime('%H:%M:%S', time.gmtime()),
+                        passe.get('title'), 'PASS')
+            results_data.append(result)
+
+        root_dir = None
+        nodejs_dir = os.path.dirname(__file__)
+        root_dir = os.path.dirname(os.path.dirname(os.path.dirname(nodejs_dir)))
+        result_log = os.path.join(root_dir, 'results-restapi-check-local.log')
+        with open(result_log, 'w') as f:
+            f.writelines(results_data)
+
+    @classmethod
+    def tearDownClass(cls):
+        '''
+        Clean up work.
+        '''
+        cls.iot_target.clean_up(cls.tc.target)

--- a/meta-iotqa/lib/oeqa/runtime/nodejs/rest_multi_ocf_servers_remote.py
+++ b/meta-iotqa/lib/oeqa/runtime/nodejs/rest_multi_ocf_servers_remote.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import time
+import json
+
+from oeqa.oetest import oeRuntimeTest
+
+sys.path.append(os.path.dirname(__file__))
+import copy_necessary_files
+import iot_config
+
+class RestApiMultiOcfServersTest(oeRuntimeTest):
+
+    iot_target = iot_config.IoTTargetConfiguration()
+
+    @classmethod
+    def setUpClass(cls):
+        '''
+        Launch the led.js and gas.js OCF servers on target device.
+        '''
+        if cls.iot_target.need_copy_files:
+            copy_necessary_files.copy_smarthome_demo_ocf_server(cls.tc.target.ip)
+
+        cls.iot_target.launch_ocf_server(cls.tc.target.ip, 'led.js')
+        cls.iot_target.launch_ocf_server(cls.tc.target.ip, 'gas.js')
+        time.sleep(cls.iot_target.wait_launch_ocf_server)
+
+        cls.iot_target.prepare_test(cls.tc.target)
+        cls.iot_target.send_multi_requests(cls.tc.target.ip, 2)
+
+    def test_multi_ocf_devices_remote(self):
+        '''
+        Send REST request and find mutiple OCF device.
+        '''
+        response = self.iot_target.session.get(self.iot_target.url_oic_d.format(ip = self.target.ip))
+        data = response.content
+        devices = json.loads(data.decode('utf8'))
+
+        devLedFound = False
+        devGasFound = False
+
+        for device in devices:
+            if device.get('n') == 'Smart Home LED':
+                devLedFound = True
+
+            if device.get('n') == 'Smart Home Gas Sensor':
+                devGasFound = True
+
+        self.assertEqual(2, len(devices), 'Only the LED & gas devices should be found!')
+        self.assertTrue(devLedFound, 'Smart Home LED device not found!')
+        self.assertTrue(devGasFound, 'Smart Home Gas Sensor device not found!')
+
+    def test_multi_ocf_platforms_remote(self):
+        '''
+        Send REST request and find only one OCF platform.
+        '''
+        response = self.iot_target.session.get(self.iot_target.url_oic_p.format(ip = self.target.ip))
+        data = response.content
+        platforms = json.loads(data.decode('utf8'))
+
+        self.assertEqual(2, len(platforms), 'Two OCF platforms should be found!')
+        for platform in platforms:
+            self.assertEqual('Intel', platform.get('mnmn'))
+
+    def test_multi_ocf_resources_remote(self):
+        '''
+        Send REST request and find the LED and Gas OCF resource.
+        '''
+        response = self.iot_target.session.get(self.iot_target.url_oic_res.format(ip = self.target.ip))
+        data = response.content
+        resources = json.loads(data.decode('utf8'))
+
+        ledHrefNum = 0
+        ledRt = ''
+        gasHrefNum = 0;
+        gasRt = ''
+        for resource in resources:
+            if resource.get('links')[0].get('href') == '/a/led':
+                ledHrefNum += 1
+                ledRt = resource.get('links')[0].get('rt')
+
+            if resource.get('links')[0].get('href') == '/a/gas':
+                gasHrefNum += 1
+                gasRt = resource.get('links')[0].get('rt')            
+
+        self.assertEqual(1, ledHrefNum, 'Only one LED resource should be found!')
+        self.assertEqual('oic.r.led', ledRt)
+
+        self.assertEqual(1, gasHrefNum, 'Only one gas resource should be found!')
+        self.assertEqual('oic.r.sensor.carbondioxide', gasRt)
+
+    @classmethod
+    def tearDownClass(cls):
+        '''
+        Clean up work.
+        '''
+        cls.iot_target.kill_ocf_server(cls.tc.target, 'led.js')  
+        cls.iot_target.kill_ocf_server(cls.tc.target, 'gas.js')
+        time.sleep(cls.iot_target.wait_kill_ocf_server)
+
+        cls.iot_target.clean_up(cls.tc.target)

--- a/meta-iotqa/lib/oeqa/runtime/nodejs/rest_one_ocf_server_remote.py
+++ b/meta-iotqa/lib/oeqa/runtime/nodejs/rest_one_ocf_server_remote.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import time
+import json
+
+from oeqa.oetest import oeRuntimeTest
+
+sys.path.append(os.path.dirname(__file__))
+import copy_necessary_files
+import iot_config
+
+class RestApiOneOcfServerTest(oeRuntimeTest):
+    
+    iot_target = iot_config.IoTTargetConfiguration()
+
+    @classmethod
+    def setUpClass(cls):
+        '''
+        Launch the OCF server on target device.
+        '''
+        if cls.iot_target.need_copy_files:
+            copy_necessary_files.copy_smarthome_demo_ocf_server(cls.tc.target.ip)
+
+        cls.iot_target.launch_ocf_server(cls.tc.target.ip, 'led.js')
+        time.sleep(cls.iot_target.wait_launch_ocf_server)
+
+        cls.iot_target.prepare_test(cls.tc.target)
+        cls.iot_target.send_multi_requests(cls.tc.target.ip, 2)
+
+    def test_unique_ocf_device_remote(self):
+        '''
+        Send REST request again and find only one OCF device.
+        '''
+        response = self.iot_target.session.get(self.iot_target.url_oic_d.format(ip = self.target.ip))
+        data = response.content
+        devices = json.loads(data.decode('utf8'))
+
+        self.assertEqual(1, len(devices), 'Only one OCF device should be found!')
+        self.assertEqual('Smart Home LED', devices[0].get('n'))
+
+    def test_unique_ocf_platform_remote(self):
+        '''
+        Send a REST request again and find only one OCF platform.
+        '''
+        response = self.iot_target.session.get(self.iot_target.url_oic_p.format(ip = self.target.ip))
+        data = response.content
+        platforms = json.loads(data.decode('utf8'))
+
+        self.assertEqual(1, len(platforms), 'Only one OCF platform should be found!')
+        self.assertEqual('Intel', platforms[0].get('mnmn'))
+
+    def test_unique_ocf_resource_remote(self):
+        '''
+        Send a REST request again and find only one OCF resource.
+        '''
+        response = self.iot_target.session.get(self.iot_target.url_oic_res.format(ip = self.target.ip))
+        data = response.content
+        resources = json.loads(data.decode('utf8'))
+
+        ledHrefNum = 0
+        ledRt = ''
+
+        for resource in resources:
+            if resource.get('links')[0].get('href') == '/a/led':
+                ledHrefNum += 1
+                ledRt = resource.get('links')[0].get('rt')
+
+        self.assertEqual(1, ledHrefNum, 'Only one LED resource should be found!')
+        self.assertEqual('oic.r.led', ledRt)
+
+    @classmethod
+    def tearDownClass(cls):
+        '''
+        Clean up work.
+        '''
+        cls.iot_target.kill_ocf_server(cls.tc.target, 'led.js')
+        time.sleep(cls.iot_target.wait_kill_ocf_server)
+
+        cls.iot_target.clean_up(cls.tc.target)

--- a/meta-iotqa/lib/oeqa/runtime/nodejs/rest_stability.py
+++ b/meta-iotqa/lib/oeqa/runtime/nodejs/rest_stability.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import time
+import json
+import subprocess
+import urllib.parse
+
+from oeqa.oetest import oeRuntimeTest
+
+sys.path.append(os.path.dirname(__file__))
+import copy_necessary_files
+import iot_config
+
+class RestApiStabilityTest(oeRuntimeTest):
+
+    iot_target = iot_config.IoTTargetConfiguration()
+    test_times = 10
+    res_uuid = None
+    query_res_url = None
+    response = None
+    # test time for the stability cases, in hour
+    test_duration = 4
+
+    @classmethod
+    def setUpClass(cls):
+        '''
+        Launch the OCF server on target device.
+        '''
+        if cls.iot_target.need_copy_files:
+            copy_necessary_files.copy_smarthome_demo_ocf_server(cls.tc.target.ip)
+
+        cls.iot_target.launch_ocf_server(cls.tc.target.ip, 'led.js')
+        time.sleep(cls.iot_target.wait_launch_ocf_server)
+
+        cls.iot_target.prepare_test(cls.tc.target)
+        cls.find_res_uuid('/a/led')
+
+    def test_rest_stability_with_int_exit(self):
+        '''
+        Kill with SIGINT and restart it.
+        Then send a REST request again and find only one OCF resource.
+        '''
+        start = time.time()
+        while True:
+            self.check_query_request_test()
+            self.check_restart_and_discovery_test('-INT')
+            self.check_query_request_test()
+
+            end = time.time()
+            duration = end - start
+            if duration > self.test_duration * 3600:
+                break
+
+    def test_rest_stability_with_term_exit(self):
+        '''
+        Kill with SIGTERM and restart it.
+        Then send a REST request again and find only one OCF resource.
+        '''
+        start = time.time()
+        while True:
+            self.check_query_request_test()
+            self.check_restart_and_discovery_test('-TERM')
+            self.check_query_request_test()
+
+            end = time.time()
+            duration = end - start
+            if duration > self.test_duration * 3600:
+                break
+
+    def check_query_request_test(self):
+        '''
+        Check /api/oic/a/led?di=<xxx>
+        '''
+        query_resp = self.iot_target.session.get(self.query_res_url)
+        status = query_resp.status_code
+        self.assertEqual(200, status, 'Response error!')
+
+    def check_restart_and_discovery_test(self, signal):
+        '''
+        Shutdown the OCF server: 
+            Check /api/oic/a/led?di=<xxx>
+        Restart the OCF server:
+            Check /api/oic/res
+        '''
+        # Close LED resource with SIGINT and the resource should disappear
+        self.iot_target.kill_ocf_server(self.target, 'led.js', signal)
+        time.sleep(self.iot_target.wait_kill_ocf_server)
+
+        query_status_cmd = 'curl -s -o /dev/null -w %{http_code} --noproxy "*" ' + self.query_res_url
+        query_proc = subprocess.Popen(query_status_cmd.split(),stdout = subprocess.PIPE, stderr = subprocess.STDOUT)
+        query_proc.wait()
+        status = query_proc.stdout.read().strip().decode('utf8')
+        self.assertEqual('404', status, 'OCF server is down, the resource should disappear!')
+
+        # Restart
+        self.iot_target.launch_ocf_server(self.target.ip, 'led.js')
+        time.sleep(self.iot_target.wait_launch_ocf_server)
+        response = self.iot_target.session.get(self.iot_target.url_oic_res.format(ip = self.target.ip))
+        status = response.status_code
+        self.assertEqual(200, status, 'Response error!')
+
+        ledHrefNum = 0
+        ledRt = ''
+
+        data = response.content
+        resources = json.loads(data.decode('utf8'))
+        for resource in resources:
+            if resource.get('links')[0].get('href') == '/a/led':
+                ledHrefNum += 1
+                ledRt = resource.get('links')[0].get('rt')
+        self.assertEqual(1, ledHrefNum, 'Only one LED resource should be found!')
+        self.assertEqual('oic.r.led', ledRt)
+
+    @classmethod
+    def find_res_uuid(cls, res_path):
+        '''
+        Find a resource uuid with res_path.
+        '''
+        cls.response = cls.iot_target.session.get(cls.iot_target.url_oic_res.format(ip = cls.tc.target.ip))
+        data = cls.response.content
+        resources = json.loads(data.decode('utf8'))
+        for resource in resources:
+            if resource.get('links')[0].get('href') == res_path:
+                cls.res_uuid = resource.get('di')
+        if cls.res_uuid:
+            cls.query_res_url = urllib.parse.urljoin(cls.iot_target.url_oic_res.format(
+                                                    ip = cls.tc.target.ip),
+                                                    'a/led?di={uuid}'.format(uuid = cls.res_uuid))
+        print(cls.query_res_url)
+
+    @classmethod
+    def tearDownClass(cls):
+        '''
+        Clean up work.
+        '''
+        cls.iot_target.kill_ocf_server(cls.tc.target, 'led.js')
+        time.sleep(cls.iot_target.wait_kill_ocf_server)
+
+        cls.iot_target.clean_up(cls.tc.target)


### PR DESCRIPTION
* Add 12 test cases for checking if REST API server returns duplicate entries of same
OCF devices/platforms/resources in the discovered list
* Add 2 stability test cases for the REST API server.

Tested on Joule with IoT RefKit image#107
New:14 Pass:14 Failed:0

Signed-off-by: Zhong Qiu <zhongx.qiu@intel.com>