### PR TITLE
Remove explicit EFI subfolder copy when creating a FAT partition

### DIFF
--- a/meta-refkit/lib/image-dsk.py
+++ b/meta-refkit/lib/image-dsk.py
@@ -44,7 +44,9 @@ def populate_rawcopy(src, dst):
 def populate_vfat(src, dst):
     """Create and populate a FAT partition, out of a root directory <src>."""
     check_call(['mkdosfs', dst])
-    check_call(['mcopy', '-i', dst, '-s', src + '/EFI', '::/'])
+    """this requires shell expansion for wildcard
+    check_call(['mcopy', '-i', dst, '-s', src + '/*', '::/'])"""
+    os.system('mcopy -i ' + dst + ' -s ' + src + '/* ::/')
 
 
 def populate_ext4(src, dst):


### PR DESCRIPTION
In order to properly copy rmc.db and other EFI partition contents,
remove explicit EFI subfolder copy and instead copy all boot/ contents
to the EFI partition. Also make the EFI partitions larger to properly
fit all the contents and the total image size 64 MB under 4 GB.

Signed-off-by: Jussi Laako <jussi.laako@linux.intel.com>