### PR TITLE
Synchronize partition sizes for different image types

### DIFF
--- a/meta-refkit/classes/image-dsk.bbclass
+++ b/meta-refkit/classes/image-dsk.bbclass
@@ -75,7 +75,7 @@ DSK_IMAGE_LAYOUT ??= ' \
     "partition_01_primary_uefi_boot": { \
         "name": "primary_uefi", \
         "uuid": 0, \
-        "size_mb": 15, \
+        "size_mb": 32, \
         "source": "${IMAGE_ROOTFS}/boot/", \
         "filesystem": "vfat", \
         "type": "${PARTITION_TYPE_EFI}" \
@@ -83,7 +83,7 @@ DSK_IMAGE_LAYOUT ??= ' \
     "partition_02_secondary_uefi_boot": { \
         "name": "secondary_uefi", \
         "uuid": 0, \
-        "size_mb": 15, \
+        "size_mb": 32, \
         "source": "${IMAGE_ROOTFS}/boot/", \
         "filesystem": "vfat", \
         "type": "${PARTITION_TYPE_EFI_BACKUP}" \
@@ -91,7 +91,7 @@ DSK_IMAGE_LAYOUT ??= ' \
     "partition_03_rootfs": { \
         "name": "rootfs", \
         "uuid": "${REMOVABLE_MEDIA_ROOTFS_PARTUUID_VALUE}", \
-        "size_mb": 3700, \
+        "size_mb": 3968, \
         "source": "${IMAGE_ROOTFS}", \
         "filesystem": "ext4", \
         "type": "8300" \

--- a/meta-refkit/wic/refkit-directdisk.wks.in
+++ b/meta-refkit/wic/refkit-directdisk.wks.in
@@ -4,6 +4,6 @@
 # EFI stub, kernel, kernel cmdline, and the initrd
 
 bootloader --ptable gpt
-part --source rootfs --rootfs-dir=${IMAGE_ROOTFS}/boot --fstype=vfat --fixed-size 30M --label primary_uefi --part-type C12A7328-F81F-11D2-BA4B-00A0C93EC93B --align 1024 --use-uuid
-part --source rootfs --rootfs-dir=${IMAGE_ROOTFS}/boot --fstype=vfat --fixed-size 30M --label secondary_uefi --part-type E3C9E316-0B5C-4DB8-817D-F92DF00215AE --align 1024 --use-uuid
-part / --source rootfs --fixed-size 3700M --fstype=ext4 --label rootfs --align 1024 --uuid ${REMOVABLE_MEDIA_ROOTFS_PARTUUID_VALUE}
+part --source rootfs --rootfs-dir=${IMAGE_ROOTFS}/boot --fstype=vfat --fixed-size 32M --label primary_uefi --part-type C12A7328-F81F-11D2-BA4B-00A0C93EC93B --align 1024 --use-uuid
+part --source rootfs --rootfs-dir=${IMAGE_ROOTFS}/boot --fstype=vfat --fixed-size 32M --label secondary_uefi --part-type E3C9E316-0B5C-4DB8-817D-F92DF00215AE --align 1024 --use-uuid
+part / --source rootfs --fixed-size 3968M --fstype=ext4 --label rootfs --align 1024 --uuid ${REMOVABLE_MEDIA_ROOTFS_PARTUUID_VALUE}


### PR DESCRIPTION
Increase dsk image type EFI partition sizes and use power of two size
for EFI partitions. Also make the rootfs size 4096 - 64 - 2*32, 64 MB
smaller than assumed 4 GB of minimum storage to leave some extra space
for other possible uses and alignment purposes but avoiding wasting
space.

Signed-off-by: Jussi Laako <jussi.laako@linux.intel.com>