### PR TITLE
test-iot.bbclass: let the set of test cases be extended bitbake-time.

### DIFF
--- a/meta-iotqa/classes/test-iot.bbclass
+++ b/meta-iotqa/classes/test-iot.bbclass
@@ -46,6 +46,15 @@ TESTIMAGEDEPENDS_append = " ${IOTQA_TASK_DEPENDS}"
 # is a profile (IOW currently image base-) name.
 IOTQA_EXTRA_TESTS ?= ""
 
+# You can include extra bitbake variables in builddata.json by
+# adding (appending) the variable name to this variable. The
+# value of extra variable 'var' will be made available as
+#
+#     <builddata.json>['extra']['var']
+#
+# IOW it should be available as TextContext.d.extra.var.
+IOTQA_EXTRA_BUILDDATA ?= ""
+
 #get layer dir
 def get_layer_dir(d, layer):
     bbpath = d.getVar("BBPATH", True).split(':')
@@ -155,6 +164,13 @@ def export_testsuite(d, exportdir):
             f.write(code)
 
 #dump build data to external file
+def get_extra_savedata(d, savedata):
+    extra = {}
+    for var in (d.getVar("IOTQA_EXTRA_BUILDDATA") or '').split():
+        val = d.getVar(var) or ''
+        extra[var] = val
+    savedata["extra"] = extra
+
 def dump_builddata(d, tdir):
     import json
 
@@ -168,6 +184,8 @@ def dump_builddata(d, tdir):
             savedata["pkgmanifest"] = [ pkg.strip() for pkg in pkgs ]
     except IOError as e:
         bb.fatal("No package manifest file found: %s" % e)
+
+    get_extra_savedata(d, savedata)
 
     bdpath = os.path.join(tdir, "builddata.json")
     with open(bdpath, "w+") as f:


### PR DESCRIPTION
 Added a variable to allow the set of test cases in the generated
testplan to be extended dynamically during bitbake time. Simply
append the fully qualified name of test cases to IOTQA_EXTRA_TESTS
and they will be included in the test plan. Test cases are declared
in the form

```
  tc1[,tc2[,tc3...]][:image1[,image2[,image3...]]]
```

An omitted image or an explicit '*' will match all image (profile) names.

For example, here's how to conditionally include an extra test in refkit-image-minimal:

```
  IOTQA_EXTRA_TESTS_append = " \
      ${@bb.utils.contains('FINGERNAILS', 'long-sharp-sticks', \
           'oeqa.runtime.sadistic.test:refkit-image-minimal', '', d)} \
      "
```
or here is how to include extra tests in several images (profiles):

```    
  IOTQA_EXTRA_TESTS_append = " \
      oeqa.foo.bar1,oeqa.foo.bar2:this-image,that-image \
      oeqa.bar.xyzzy,oeqa.bar.barf:some-other-image \
  "
````

Moreover,  let the set of saved globally visible bitbake variables be
extended by listing extra variable names in IOTQA_EXTRA_BUILDDATA.
The value of each extra variable 'var' will be made available as

```
        <builddata.json>['extra']['var']
```
    
IOW it should be available as 

```
    TextContext.d.extra.var
```

in your testcase code.

Signed-off-by: Krisztian Litkey <krisztian.litkey@intel.com>