### PR TITLE
meta-iotqa: Ignore one alsa boot error

### DIFF
--- a/meta-iotqa/lib/oeqa/runtime/sanity/baseos.py
+++ b/meta-iotqa/lib/oeqa/runtime/sanity/baseos.py
@@ -106,7 +106,9 @@ class BaseOsTest(oeRuntimeTest):
             "ACPI Error: Could not enable RealTimeClock event",
             "hci_intel: probe of INT33E1:00 failed with error -2",
             "Error changing net interface name 'usb0' to",
-            "*ERROR* dp aux hw did not signal timeout"
+            "*ERROR* dp aux hw did not signal timeout",
+            # Bug 11105, in Refkit bugzilla
+            "file /var/lib/alsa/asound.state lock error"
             ]
         self.longMessage = True
         cmd = "journalctl -ab"


### PR DESCRIPTION
The error: "/usr/sbin/alsactl: state_lock:125: file
/var/lib/alsa/asound.state lock error: File exists" happens randomly under 2% of
the time so it's really hard to replicate and test if it affects
anything. Also there seems to be no fix for it so ignore the error.

Signed-off-by: Simo Kuusela <simo.kuusela@intel.com>