### PR TITLE
Add and enable mraa GPIO tests

### DIFF
--- a/meta-iotqa/conf/test/refkit-image-common.manifest
+++ b/meta-iotqa/conf/test/refkit-image-common.manifest
@@ -5,6 +5,7 @@ oeqa.runtime.sanity.comm_managerdaemon
 oeqa.runtime.sanity.comm_btcheck
 oeqa.runtime.sanity.apprt_python
 oeqa.runtime.sanity.mraa_hello
+oeqa.runtime.sanity.mraa_gpio
 oeqa.runtime.sanity.iotivity
 oeqa.runtime.alsa.alsa
 oeqa.runtime.sanity.upm

--- a/meta-iotqa/lib/oeqa/runtime/sanity/mraa_gpio.py
+++ b/meta-iotqa/lib/oeqa/runtime/sanity/mraa_gpio.py
@@ -1,0 +1,44 @@
+from oeqa.oetest import oeRuntimeTest
+import unittest
+import subprocess
+from time import sleep
+
+class MraaGpioTest(oeRuntimeTest):
+    '''
+    These tests require to use BeagleBone as testing host
+    '''
+    pin = ""
+    def setUp(self):
+        (status, output)= self.target.run("mraa-gpio version")
+        output = output.lower()
+        if any(x in output for x in ("broxton", "tuchuck", "joule")):
+            self.pin = "51"
+        elif "minnowboard" in output:
+            self.pin = "25"
+        else:
+            raise unittest.SkipTest(output)
+
+    def test_gpio(self):
+        '''
+        Test a GPIO pin on and off and check the pin output with
+        BeagleBone
+        '''
+        def check_gpio_output():
+            cmd = "cat /sys/class/gpio/gpio20/value".split()
+            output = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
+            return int(output)
+
+        self.target.run("mraa-gpio set " + self.pin + " 0")
+        sleep(1)
+        output = check_gpio_output()
+        self.assertEqual(output, 0, msg="GPIO pin output is not 0")
+
+        self.target.run("mraa-gpio set " + self.pin + " 1")
+        sleep(1)
+        output = check_gpio_output()
+        self.assertEqual(output, 1, msg="GPIO pin output is not 1")
+
+        self.target.run("mraa-gpio set " + self.pin + " 0")
+        sleep(1)
+        output = check_gpio_output()
+        self.assertEqual(output, 0, msg="GPIO pin output is not 0")


### PR DESCRIPTION
These tests will set a GPIO pin on and off and check the output with BeagleBone that it works.