### PR TITLE
CI: run oe-selftests as pre-build, post-build steps

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,9 +16,7 @@
 
 def is_pr = env.JOB_NAME.endsWith("_pull-requests")
 
-// an example how to build for multiple machines:
-//def target_machines = [ "intel-corei7-64", "intel-quark" ]
-def target_machines = [ "intel-corei7-64" ]
+def target_machine = "intel-corei7-64"
 
 // test on these HW targets:
 def test_devices = [ "570x", "minnowboardturbot" ]
@@ -59,8 +57,6 @@ def script_env_global = """
 
 try {
     def build_runs = [:]
-    for(int i=0; i < target_machines.size(); i++) {
-        def target_machine = target_machines[i]
         build_runs["build_${target_machine}"] = {
             node('rk-docker') {
                 ws("workspace/builder-slot-${env.EXECUTOR_NUMBER}") {
@@ -111,7 +107,6 @@ try {
                 } // ws
             } // node
         } // build_runs =
-    } // for
 
     stage('Build') {
         if (is_pr) {
@@ -124,16 +119,12 @@ try {
 
     // find out combined size of all testinfo files
     int testinfo_sumz = 0
-    for(int i=0; i < target_machines.size(); i++) {
-        testinfo_sumz += testinfo_data["${target_machines[i]}"].length()
-    }
+    testinfo_sumz += testinfo_data["${target_machine}"].length()
     // skip tester parts if no tests configured
     if ( testinfo_sumz > 0 ) {
         def test_runs = [:]
         for(int i = 0; i < test_devices.size(); i++) {
             def test_device = test_devices[i]
-            for(int k = 0; k < target_machines.size(); k++) {
-                def target_machine = target_machines[k]
                 // only if built for machine that this tester wants
                 if ( target_machine == mapping["${test_device}"] ) {
                     // testinfo_data may contain multiple lines stating different images
@@ -196,7 +187,6 @@ try {
                         } // test_runs =
                     } // for m
 	        } // if target_machine == mapping
-            } // for k
         } // for i
         stage('Parallel test run') {
             if (is_pr) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -75,7 +75,6 @@ try {
                     def script_env_local = """
                         export TARGET_MACHINE=${target_machine}
                     """
-                    sshagent(['github-auth-ssh']) {
                         docker_image.inside(run_args) {
                             try {
                                 params = ["${script_env_global}", "${script_env_local}",
@@ -98,7 +97,6 @@ try {
                                 sh "${params}"
                             }
                         } // docker_image
-                    } // sshagent
                     // cleanup image (disabled for now, as would remove caches)
                     // sh "docker rmi ${image_name}"
                     tester_script = readFile "docker/tester-exec.sh"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -63,7 +63,7 @@ try {
         def target_machine = target_machines[i]
         build_runs["build_${target_machine}"] = {
             node('rk-docker') {
-                ws ("workspace/builder-slot-${env.EXECUTOR_NUMBER}") {
+                ws("workspace/builder-slot-${env.EXECUTOR_NUMBER}") {
                     deleteDir()
                     checkout_content(is_pr)
                     build_docker_image(image_name)
@@ -89,9 +89,9 @@ try {
                                 "docker/publish-project.sh"].join("\n")
                                 sh "${params}"
                             }
-                        }
+                        } // docker_image
                     } // sshagent
-                    // all good, cleanup image (disabled for now, as also removes caches)
+                    // cleanup image (disabled for now, as would remove caches)
                     // sh "docker rmi ${image_name}"
                     tester_script = readFile "docker/tester-exec.sh"
                     testinfo_data["${target_machine}"] = readFile "${target_machine}.testinfo.csv"
@@ -108,10 +108,10 @@ try {
     } // for
 
     stage('Build') {
+        if (is_pr) {
+           setGitHubPullRequestStatus state: 'PENDING', context: "${env.JOB_NAME}", message: "Building"
+        }
         timestamps {
-            if (is_pr) {
-                setGitHubPullRequestStatus state: 'PENDING', context: "${env.JOB_NAME}", message: "Building"
-            }
             parallel build_runs
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -79,7 +79,15 @@ try {
                         docker_image.inside(run_args) {
                             try {
                                 params = ["${script_env_global}", "${script_env_local}",
+                                "docker/pre-build.sh"].join("\n")
+                                sh "${params}"
+
+                                params = ["${script_env_global}", "${script_env_local}",
                                 "docker/build-project.sh"].join("\n")
+                                sh "${params}"
+
+                                params = ["${script_env_global}", "${script_env_local}",
+                                "docker/post-build.sh"].join("\n")
                                 sh "${params}"
                             } catch (Exception e) {
                                 throw e

--- a/docker/build-project.sh
+++ b/docker/build-project.sh
@@ -80,6 +80,9 @@ EOF
   fi
   # Buildhistory mode set always in CI run
   cat >> conf/auto.conf << EOF
+INHERIT += "buildhistory"
+BUILDHISTORY_COMMIT = "1"
+INHERIT += "buildhistory-extra"
 BUILDHISTORY_DIR ?= "${BUILDHISTORY_TMP}"
 EOF
   if [ ! -z ${COORD_BASE_URL+x} ]; then

--- a/docker/post-build.sh
+++ b/docker/post-build.sh
@@ -1,0 +1,34 @@
+#!/bin/bash -xeu
+# build-project.sh: Post-build steps
+# Copyright (c) 2017, Intel Corporation.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms and conditions of the GNU General Public License,
+# version 2, as published by the Free Software Foundation.
+#
+# This program is distributed in the hope it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+
+# bitbake started to depend on a locale with UTF-8 support
+# when migrating to Python3.
+export LC_ALL=en_US.UTF-8
+
+cd $WORKSPACE
+
+# use +u to avoid exit caused by unbound variables use in init scripts
+set +u
+# note, BUILD_DIR is also undef in CI case, but is set in local-build case.
+source refkit-init-build-env ${BUILD_DIR}
+set -u
+
+if [ ! -z ${JOB_NAME+x} ]; then
+  # in CI: run post-build oe-selftests using development-mode settings in auto.conf
+  # we can't use full auto.conf of builder, oe-selftest does not like buildhistory=ON
+  echo "include conf/distro/include/refkit-development.inc" > ${WORKSPACE}/build/conf/auto.conf
+  _tests=`grep REFKIT_CI_POSTBUILD_SELFTESTS ${WORKSPACE}/refkit_ci_vars | perl -pe 's/.+="(.*)"/\1/g; s/[^ .a-zA-Z0-9_-]//g'`
+  if [ -n "$_tests" ]; then
+    oe-selftest --run-tests ${_tests}
+  fi
+fi

--- a/docker/pre-build.sh
+++ b/docker/pre-build.sh
@@ -1,0 +1,51 @@
+#!/bin/bash -xeu
+# pre-build.sh: Pre-build steps
+# Copyright (c) 2017, Intel Corporation.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms and conditions of the GNU General Public License,
+# version 2, as published by the Free Software Foundation.
+#
+# This program is distributed in the hope it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+
+# Catch errors in pipelines
+set -o pipefail
+
+# bitbake started to depend on a locale with UTF-8 support
+# when migrating to Python3.
+export LC_ALL=en_US.UTF-8
+
+cd $WORKSPACE
+
+# document env.vars in build log
+env |sort
+
+# use +u to avoid exit caused by unbound variables use in init scripts
+set +u
+# note, BUILD_DIR is also undef in CI case, but is set in local-build case.
+source refkit-init-build-env ${BUILD_DIR}
+set -u
+
+# Take local CI preferences if present, 1st time, to get bb_e_env parsed
+if [ -f $WORKSPACE/meta-*/conf/distro/include/refkit-ci.inc ]; then
+  cat $WORKSPACE/meta-*/conf/distro/include/refkit-ci.inc > conf/auto.conf
+fi
+
+# use bitbake -e for variables parsing, then pick REFKIT_CI part
+bitbake -e >bb_e_out 2>bb_e_err || (cat bb_e_err && false)
+grep -E "^REFKIT_CI" bb_e_out > ${WORKSPACE}/refkit_ci_vars || true
+
+if [ ! -z ${JOB_NAME+x} ]; then
+  # in CI: run pre-build oe-selftests using development-mode settings in auto.conf
+  # we can't use full auto.conf of builder, oe-selftest does not like buildhistory=ON
+  echo "include conf/distro/include/refkit-development.inc" > ${WORKSPACE}/build/conf/auto.conf
+  _tests=`grep REFKIT_CI_PREBUILD_SELFTESTS ${WORKSPACE}/refkit_ci_vars | perl -pe 's/.+="(.*)"/\1/g; s/[^ .a-zA-Z0-9_-]//g'`
+  if [ -n "$_tests" ]; then
+    oe-selftest --run-tests ${_tests}
+  fi
+  rm -f ${WORKSPACE}/build/conf/auto.conf
+fi
+

--- a/meta-refkit/conf/distro/include/refkit-ci.inc
+++ b/meta-refkit/conf/distro/include/refkit-ci.inc
@@ -55,6 +55,11 @@ require conf/distro/include/refkit-development.inc
 REFKIT_VM_IMAGE_TYPES = "wic.xz wic.zip wic.bmap wic.xz.sha256sum"
 
 #
+# pre/post-build oe-selftests started by CI builder, whitespace-separated.
+#
+REFKIT_CI_PREBUILD_SELFTESTS="iotsstatetests.SStateTests.test_sstate_samesigs"
+REFKIT_CI_POSTBUILD_SELFTESTS=""
+#
 # Automated build targets
 # Those targets should be space separated list of items,
 # which must contain only alphanumeric symbols,'-' and '_'.

--- a/meta-refkit/conf/distro/include/refkit-ci.inc
+++ b/meta-refkit/conf/distro/include/refkit-ci.inc
@@ -26,12 +26,7 @@ ISAFW_LA_PLUGIN_IMAGE_WHITELIST = "refkit-image-minimal refkit-initramfs"
 # image files are not needed for that.
 IMAGE_FSTYPES_pn-refkit-image-minimal = ""
 REFKIT_VM_IMAGE_TYPES_pn-refkit-image-minimal = ""
-
-# Enable extended buildhistory:
-INHERIT += "buildhistory"
-BUILDHISTORY_COMMIT = "1"
-INHERIT += "buildhistory-extra"
-
+ 
 # Test data generation:
 INHERIT += "test-iot"
 TEST_EXPORT_DIR = "iottest"

--- a/meta-refkit/lib/oeqa/selftest/iotsstatetests.py
+++ b/meta-refkit/lib/oeqa/selftest/iotsstatetests.py
@@ -33,7 +33,8 @@ class SStateTests(SStateBase):
         libcappend = get_bb_var('TCLIBCAPPEND')
         # Select subset of the machines to speed up testing.
         # Edison/intel-core2-32 are particularly sensitive.
-        machines = "edison intel-quark intel-core2-32 intel-corei7-64 beaglebone".split()
+        machines = "intel-corei7-64".split()
+        # machines = "edison intel-quark intel-core2-32 intel-corei7-64 beaglebone".split()
         # machines = "edison intel-core2-32".split()
         first = machines[0]
         workdir = os.getcwd()


### PR DESCRIPTION
First 5 commits are re-factoring of Jenkinsfile, as I prepared to introduce separate stage where prebuild
would run. 
After that done, I was advised to insert prebuild test in build script. 
That was done in 6th commit.
Commit 7 drops use of ssh-agent on docker session as we seem to get repos accessed without it.
Then the plan changed again and pre- and -post steps were added as separate stages and scripts
in commits 8,9 with build step un-parallelised (one MACHINE).
This restored some stages taken away in refactoring.
Commit 11 clarifies build script parts by moving some more sub-steps to CI-only sections, freeing
local build from CI and tester related steps.
last commit 12 moves enablement of BUILDHISTORY from refkit-ci.inc into build-project.sh, thus freeing
refkit-ci.inc to be used in oe-selftest runs, taking away need to overwrite auto.conf, and making pre-build and post-build scripts simpler. Note that post-build script has to reset auto.conf anyway because build phase inserted BUILDHISTORY setting there. But now the auto.conf can be rewritten using refkit-ci.inc
