### PR TITLE
meta-iotqa: Disable opencl test for Minnowboard Turbot

### DIFF
--- a/meta-iotqa/conf/test/minnowboardturbot.mask
+++ b/meta-iotqa/conf/test/minnowboardturbot.mask
@@ -1,2 +1,3 @@
 # This file contains tests that can't be run on Minnowboard Turbot
 # /docker/tester-exec.sh will use this file to remove tests from a manifest
+oeqa.runtime.computervision.opencl_viennacl_1


### PR DESCRIPTION
The test doesn't work with it and causes this error when running:
drm_intel_gem_bo_context_exec() failed: Device or resource busy
Beignet: "Exec event 0x557ea96c6720 error, type is 4592, error staus is -5"

Signed-off-by: Simo Kuusela <simo.kuusela@intel.com>