### PR TITLE
Add thermald for thermal management

### DIFF
--- a/meta-refkit/classes/refkit-image.bbclass
+++ b/meta-refkit/classes/refkit-image.bbclass
@@ -174,6 +174,10 @@ IMAGE_INSTALL += "util-linux"
 export ALTERNATIVE_PRIORITY_SHADOW ?= "305"
 IMAGE_INSTALL += "shadow"
 
+# Install thermal management daemon by default for
+# handling platform thermal management.
+IMAGE_INSTALL += "thermald"
+
 # Common profile has "packagegroup-common-test" that has packages that are
 # used only in "development" configuration.
 FEATURE_PACKAGES_common-test = "packagegroup-common-test"

--- a/meta-refkit/conf/distro/include/refkit-supported-recipes.txt
+++ b/meta-refkit/conf/distro/include/refkit-supported-recipes.txt
@@ -269,6 +269,7 @@ systemd@core
 taglib@core
 tbb@openembedded-layer
 tcp-smack-test@security-smack
+thermald@intel
 tiff@core
 tpm-tools@security
 tremor@core


### PR DESCRIPTION
In order to allow platform thermal management, add thermald to the base
image configuration.

Signed-off-by: Jussi Laako <jussi.laako@linux.intel.com>