### PR TITLE
tester-exec.sh: Minor changes

### DIFF
--- a/docker/tester-exec.sh
+++ b/docker/tester-exec.sh
@@ -28,7 +28,7 @@ testimg() {
 
   # Copy local WLAN settings to iottest over example file and chmod to readable
   _WLANCONF=./iottest/oeqa/runtime/sanity/files/config.ini
-  cp /home/tester/.config.ini.wlan ${_WLANCONF}
+  cp $HOME/.config.ini.wlan ${_WLANCONF}
   chmod 644 ${_WLANCONF}
 
   # Get image(s)

--- a/docker/tester-exec.sh
+++ b/docker/tester-exec.sh
@@ -109,7 +109,8 @@ testimg() {
   # create summary file to be used in email notification sending
   _reports=`ls TEST-${DEVICE}.${_IMG_NAME}.*.xml`
   num_total=0
-  num_skipped=$((0+num_masked))
+  num_skipped=0
+  num_na=$((0+num_masked))
   num_failed=0
   num_error=0
   for _r in $_reports; do
@@ -126,7 +127,7 @@ testimg() {
   sumfile=results-summary-${DEVICE}.${_IMG_NAME}.log
   echo "Image: ${FILENAME}" > $sumfile
   echo "  Device: ${DEVICE}" >> $sumfile
-  echo "  Total:$num_total  Pass:$num_passed  Fail:$num_failed  Skip:$num_skipped  Error:$num_error" >> $sumfile
+  echo "  Total:$num_total  Pass:$num_passed  Fail:$num_failed  Skip:$num_skipped  Error:$num_error  N/A:$num_na" >> $sumfile
   if [ $num_total -gt 0 ]; then
     run_rate=$((100*run_total/num_total))
     pass_rate_of_total=$((100*num_passed/num_total))


### PR DESCRIPTION
Report masked tests as 'N/A'. Don't sum masked tests to skipped tests. This way run rate and pass rate of total will be 100% if there is masked tests but no skipped ones. Also change '/home/tester' to $HOME variable which makes this script more portable.
