### PR TITLE
readme: fix spelling and clarity in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,21 +2,28 @@ intel-iot-refkit
 ################
 
 This README file contains information on setting up, building, and booting
-Iot Reference OS Kit for Intel(r) Architecture project.
+the IoT Reference OS Kit for Intel(r) Architecture project.
+
+.. note::
+
+   Only Linux development hosts are currently supported, as documented
+   in the `Yocto Project Quick Start Guide`_
+
+.. Yocto Project Quick Start Guide: http://www.yoctoproject.org/docs/current/yocto-project-qs/yocto-project-qs.html#the-linux-distro
 
 Installing Docker on Linux
 ==========================
 
-It's possible to build the project in a Docker container. Using Docker provides
+We recommend you build projects in a Docker container. Using Docker provides
 a packaged and controlled environment for building an
-image, eliminating development environment issues that
+image and can eliminate development environment issues that
 can occur with differing Linux OS distros and versions, different host
-compilers, and such. (There are instructions later below for building
-without Docker.)
+compilers, and such. (We also describe `building without docker`_ in the
+instructions below.)
 
 Instructions for installing Docker for common Linux distros on your
 development machine (including Fedora and Ubuntu) are available at:
-https://docs.docker.com/engine/installation/linux
+https://docs.docker.com/engine/installation/linux.
 
 .. _Optional Docker Configuration: https://docs.docker.com/engine/installation/linux/ubuntulinux/#Optional%20Configurations
 .. _configure the DNS server for Docker: https://docs.docker.com/engine/installation/linux/ubuntulinux/#configure-a-dns-server-for-use-by-docker
@@ -54,7 +61,7 @@ Building with Docker
 ====================
 
 These instructions assume you’ll be working with the sources in a
-`~/work/intel-iot-refkit` directory that you’ll be creating.
+``~/work/intel-iot-refkit`` directory that you’ll be creating.
 
 Start by cloning the GitHub repos. If you have a previous copy of this
 repository without all the submodules, it would be best to remove all
@@ -65,11 +72,14 @@ $ mkdir -p $HOME/work
 $ cd $HOME/work
 $ git clone --recursive https://github.com/intel/intel-iot-refkit.git
 $ cd $WORKSPACE
+
 When Docker is configured properly and all project code is cloned and
 available locally, it's time to trigger a build. To do this run the
 command from within the ``~/work/intel-iot-refkit`` directory::
 
 $ docker/local-build.sh
+
+.. building witout docker:
 
 Building without Docker
 =======================
@@ -79,7 +89,7 @@ While not recommended, you can also use Yocto Project bitbake directly.
 reproducible and debuggable by other developers using a different
 distribution.)
 
-Here are the basic steps, preparation::
+Here are the basic preparation steps::
 
 $ mkdir -p $HOME/work
 $ cd $HOME/work
@@ -90,7 +100,7 @@ $ source refkit-init-build-env
 Edit :file:`conf/local.conf` to select whether to build the production or the development image.
 More details about the choices in that file.
 
-Basic steps, build::
+Basic build steps::
 
 $ bitbake refkit-image-common
 
@@ -109,7 +119,7 @@ https://git-scm.com/docs/git-submodule
 Installing the Images
 =====================
 
-See detailed instructions in doc/howtos/image-install.rst.
+See detailed instructions in `how to install images <doc/howtos/image-install.rst>`_.
 
 Mailing Lists
 =============


### PR DESCRIPTION
Fixed some spelling and grammar issues, and made clarity edits.

Added link to building without docker section.

Clarified only linux build environment supported.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>