### PR TITLE
README.rst: mention possibility to give argument to local build

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,7 +69,13 @@ When Docker is configured properly and all project code is cloned and
 available locally, it's time to trigger a build. To do this run the
 command from within the ``~/work/intel-iot-refkit`` directory::
 
+Build all pre-configured target images with test suites::
+
 $ docker/local-build.sh
+
+Specify one or more target image(s)::
+
+$ docker/local-build.sh refkit-image-common
 
 Building without Docker
 =======================


### PR DESCRIPTION
local-build.sh allows to build just subset of images, but we don't
mention this possibility in README.
If started without arguments, target image list is parsed from 
CI settings and will include
all images used in CI, plus test suites.

Signed-off-by: Olev Kartau <olev.kartau@intel.com>