### PR TITLE
meta-iotqa: extend runtest.py to accept target's port number

### DIFF
--- a/meta-iotqa/README.md
+++ b/meta-iotqa/README.md
@@ -37,7 +37,7 @@ $ tar xvf iot-testfiles.xxx.tar.gz -C iottest/
 Running the tests:
 ```
 $ cd iottest
-$ python runtest.py -f testplan/xxx.manifest -m [target machine] -t [target IP] -s [host IP]
+$ python runtest.py -f testplan/xxx.manifest -m <target machine> -t <target IP>[:<port number>] -s <host IP>
 ```
 
 For example:

--- a/meta-iotqa/lib/runtest.py
+++ b/meta-iotqa/lib/runtest.py
@@ -41,6 +41,7 @@ class FakeTarget(object):
     def __init__(self, d):
         self.connection = None
         self.ip = None
+        self.port = None
         self.server_ip = None
         self.datetime = time.strftime('%Y%m%d%H%M%S',time.gmtime())
         self.testdir = d.getVar("TEST_LOG_DIR", True)
@@ -56,7 +57,7 @@ class FakeTarget(object):
             print("SSH log file: %s" %  self.sshlog)
         else:
             self.sshlog = os.path.join(self.testdir, "ssh_target_log_%s_%s" % (self.ip, self.datetime))
-        self.connection = SSHControl(self.ip, logfile=self.sshlog)
+        self.connection = SSHControl(self.ip, port=self.port, logfile=self.sshlog)
 
     def run(self, cmd, timeout=None):
         return self.connection.run(cmd, timeout)
@@ -223,7 +224,8 @@ def main():
     first = True
     for ip in targets_ip:
         target = FakeTarget(d)
-        target.ip = ip
+        buf_ip = ip.split(":", 1)
+        [target.ip, target.port] = buf_ip if len(buf_ip) == 2 else [buf_ip[0], "22"]
         target.server_ip = server_ip
         target.exportStart(first)
         first = False


### PR DESCRIPTION
In case of testing a QEMU-based target it might be easier to
use SLIRP networking which doesn't require root permissions to
create a TAP network interface. But it means that the target can
be accessible only via a port forwarded to the host's loopback
interface. And as the default SSH port is usually taken already
the target's SSH port is forwarded to port 2222 on localhost.

Unfortunately the runtest.py script assumes that the SSH
port is 22 always.

This patch extends runtest.py options to accept an optional
port argument. So the command to run tests on a QEMU target
may look like the following:

    runtest.py -f testplan/refkit-image-common.manifest -m intel-corei7-64 -t 127.0.0.1:2222 -s 10.0.2.2