### PR TITLE
mraa: Add patch to fix mraa-gpio randomly crashing

### DIFF
--- a/meta-refkit/recipes-sensors/mraa/files/0001-mraa.c-Fix-strsep-crash.patch
+++ b/meta-refkit/recipes-sensors/mraa/files/0001-mraa.c-Fix-strsep-crash.patch
@@ -1,0 +1,58 @@
+From cc300c759c40611633a9253a04c0098e951977be Mon Sep 17 00:00:00 2001
+From: Simo Kuusela <simo.kuusela@intel.com>
+Date: Tue, 14 Mar 2017 11:27:30 +0200
+Subject: [PATCH 1/1] mraa.c: Fix strsep crash
+
+Variable 'dup' doesn't get freed correctly as the pointer to it changes
+after 'strsep' function is used. Also 'token' variable doesn't need to
+be freed as freeing the original 'dup' already frees the same memory.
+
+Upstream status: Accepted [https://github.com/intel-iot-devkit/mraa/commit/b24e90db0cceed81680b1a398d2a8b19be5a3fbb]
+
+Signed-off-by: Simo Kuusela <simo.kuusela@intel.com>
+---
+ src/mraa.c | 11 +++++------
+ 1 file changed, 5 insertions(+), 6 deletions(-)
+
+diff --git a/src/mraa.c b/src/mraa.c
+index 42c5bb9..e713a6d 100644
+--- a/src/mraa.c
++++ b/src/mraa.c
+@@ -947,7 +947,8 @@ mraa_find_i2c_bus_pci(const char* pci_device, const char *pci_id, const char* ad
+         }
+         else {
+             while (n--) {
+-	        char* dup = strdup(namelist[n]->d_name);
++                char* dup = strdup(namelist[n]->d_name);
++                char* orig_dup = dup;
+                 if (dup == NULL) {
+                     syslog(LOG_ERR, "Ran out of memory!");
+                     break;
+@@ -961,22 +962,20 @@ mraa_find_i2c_bus_pci(const char* pci_device, const char *pci_id, const char* ad
+                         if (token != NULL) {
+                             int ret = -1;
+                             if (mraa_atoi(token, &ret) == MRAA_SUCCESS) {
+-                                free(dup);
++                                free(orig_dup);
+                                 free(namelist[n]);
+                                 free(namelist);
+                                 syslog(LOG_NOTICE, "Adding i2c bus found on i2c-%d on adapter %s", ret, adapter_name);
+                                 return ret;
+                             }
+-                            free(dup);
++                            free(orig_dup);
+                             free(namelist[n]);
+                             free(namelist);
+                             return -1;
+                         }
+                     }
+-                    free(token);
+-                } else {
+-                    free(dup);
+                 }
++                free(orig_dup);
+                 free(namelist[n]);
+             }
+             free(namelist);
+--
+2.9.3

--- a/meta-refkit/recipes-sensors/mraa/mraa.inc
+++ b/meta-refkit/recipes-sensors/mraa/mraa.inc
@@ -5,7 +5,8 @@ AUTHOR = "Brendan Le Foll, Tom Ingleby, Dmitry Rozhkov"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://COPYING;md5=66493d54e65bfc12c7983ff2e884f37f"
 
-SRC_URI = "git://github.com/intel-iot-devkit/mraa.git;protocol=http;tag=v${PV}"
+SRC_URI = "git://github.com/intel-iot-devkit/mraa.git;protocol=http;tag=v${PV} \
+           file://0001-mraa.c-Fix-strsep-crash.patch"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
The patch has been merged already upstream. Problem was caused by not
freeing a variable correctly.

Signed-off-by: Simo Kuusela <simo.kuusela@intel.com>