### PR TITLE
imagevariant.bbclass: handle trivial variant/feature name collisions.

### DIFF
--- a/meta-refkit/classes/imagevariant.bbclass
+++ b/meta-refkit/classes/imagevariant.bbclass
@@ -19,7 +19,7 @@
 #
 # Example for core-image-minimal.bb:
 #   IMAGE_VARIANT[dev] = "tools-debug tools-profile"
-#   BBCLASSEXTEND = "imagevariant:ptest-pkgs imagevariant:tools-debug,no-debug-tweaks imagevariant=dev"
+#   BBCLASSEXTEND = "imagevariant:ptest-pkgs imagevariant:tools-debug,no-debug-tweaks imagevariant:dev"
 #   ->
 #   core-image-minimal-ptest-pkgs (ptest-pkgs enabled)
 #   core-image-minimal-tools-debug-no-debug-tweaks (debug-tweaks disabled)

--- a/meta-refkit/classes/imagevariant.bbclass
+++ b/meta-refkit/classes/imagevariant.bbclass
@@ -46,13 +46,30 @@ python imagevariant_virtclass_handler () {
     # Expand parameter aliases, recursively.
     def expand(parameters):
         modified = []
-        for parameter in parameters:
+        recursive = []
+
+        for parameter in parameters or []:
             alias = e.data.getVarFlag('IMAGE_VARIANT', parameter, True)
+
             if alias is not None:
-                modified.extend(expand(alias.split()))
+                split_alias = alias.split()
+                if parameter in split_alias:
+                    # continue expansion with parameter removed to avoid
+                    # infinite recursion
+                    split_alias.remove(parameter)
+                    recursive.append(parameter)
+                try:
+                    modified.extend(expand(split_alias))
+                except RuntimeError as re:
+                    bb.fatal('You probably have a non-trivially ' \
+                             'expandable imagevariant (%s). ' \
+                             'Runtime error: %s.' % (variant, re))
             else:
                 modified.append(parameter)
+
+        modified.extend(recursive)
         return modified
+
     parameters = expand(parameters)
 
     # Validate parameters and apply them to IMAGE_FEATURES.


### PR DESCRIPTION
Don't go into infinite recursion for trivial namespace collision of
variants and IMAGE_FEATUREs. This happens when a variant contains an
IMAGE_FEATURE with an identical name. For instance the following sample
would fail without this patch, recursing on expanding flatpak until
the maximum recursion depth is exceeded:
```
...
IMAGE_FEATURES[validitems] += " \
    flatpak \
    tools-sdk dev-pkgs tools-debug tools-profile \
"

FEATURE_PACKAGES_flatpak = " \
    packagegroup-flatpak \
    ${@'flatpak-predefined-repos' \
         if d.getVar('FLATPAK_APP_REPOS') else ''} \
"
...

IMAGE_VARIANT[flatpak] = "flatpak"
IMAGE_VARIANT[flatpak-sdk] = "flatpak tools-develop tools-debug dev-pkgs"

BBCLASSEXTEND = "imagevariant:flatpak imagevariant:flatpak-sdk"
```
Note that we only handle reasonable to be expected trivial immediate
recursion. Difficult to follow/understand complex cases involving two
or more variant/feature pairs ([foo] = "bar foobar", [bar] = "xyzzy",
[xyzzy] = "foo") we intentionally let fail, although we now give an
error message hinting at the probably cause of the failure.
