### PR TITLE
Install machine specific packages to images

### DIFF
--- a/meta-refkit/classes/refkit-image.bbclass
+++ b/meta-refkit/classes/refkit-image.bbclass
@@ -3,11 +3,12 @@
 REFKIT_IMAGE_EXTRA_INSTALL ?= ""
 IMAGE_INSTALL = " \
 		kernel-modules \
-		linux-firmware \
 		packagegroup-core-boot \
-                ${ROOTFS_BOOTSTRAP_INSTALL} \
-                ${CORE_IMAGE_EXTRA_INSTALL} \
-                ${REFKIT_IMAGE_EXTRA_INSTALL} \
+		${MACHINE_EXTRA_RDEPENDS} \
+		${MACHINE_EXTRA_RRECOMMENDS} \
+		${ROOTFS_BOOTSTRAP_INSTALL} \
+		${CORE_IMAGE_EXTRA_INSTALL} \
+		${REFKIT_IMAGE_EXTRA_INSTALL} \
 		"
 
 # In IoT Reference OS Kit, /bin/sh is always dash, even if bash is installed for

--- a/meta-refkit/conf/distro/include/refkit-supported-recipes.txt
+++ b/meta-refkit/conf/distro/include/refkit-supported-recipes.txt
@@ -193,6 +193,7 @@ linux-firmware@core
 linux-intel@intel
 linux-libc-headers@core
 linux-yocto@core
+lms8@intel
 lowpan-tools@networking-layer
 lttng-ust@core
 m4@core
@@ -270,6 +271,7 @@ taglib@core
 tbb@openembedded-layer
 tcp-smack-test@security-smack
 tiff@core
+thermald@intel
 tpm-tools@security
 tremor@core
 trousers@security


### PR DESCRIPTION
In order to fully support machine functionality provided by BSPs,
install machine specific extra packages to the image.

Signed-off-by: Jussi Laako <jussi.laako@linux.intel.com>