### PR TITLE
CI build-project.sh: fix location of ci_git_commit file

### DIFF
--- a/docker/build-project.sh
+++ b/docker/build-project.sh
@@ -32,7 +32,7 @@ if [ ! -z ${JOB_NAME+x} ]; then
   # in CI run only:
   # get commit ID for using in buildhistory tagging, save for later use
   CI_GIT_COMMIT=$(git rev-parse HEAD)
-  echo ${CI_GIT_COMMIT} > ci_git_commit
+  echo ${CI_GIT_COMMIT} > ${WORKSPACE}/ci_git_commit
 
   # Prepare for buildhistory generation in BH branch, name of which
   # is composed from JOB_NAME and TARGET_MACHINE


### PR DESCRIPTION
Recent change moved creation of ci_git_commit into later block
which runs after env-init, so that file was created one directory
level deeper, in build/ directory. But as other parts look for
file at top level of WORKSPACE, thise broke master build
where this file is used for summary message.
Code is safer if we spefify full path in writing.

Signed-off-by: Olev Kartau <olev.kartau@intel.com>