### PR TITLE
refkit: use static DISTRO_VERSION

### DIFF
--- a/meta-refkit/classes/refkit-image.bbclass
+++ b/meta-refkit/classes/refkit-image.bbclass
@@ -384,12 +384,10 @@ ROOTFS_POSTPROCESS_COMMAND += "${@'extra_motd;' if d.getVar('REFKIT_EXTRA_MOTD',
 # FIXME: make this work with both ${IMAGE_ROOTFS}/etc/ and ${IMAGE_ROOTFS}/usr/lib
 refkit_image_patch_os_release () {
     sed -i \
-        -e 's/distro-version-to-be-added-during-image-creation/${DISTRO_VERSION}/' \
         -e 's/build-id-to-be-added-during-image-creation/${BUILD_ID}/' \
         ${IMAGE_ROOTFS}/etc/os-release
 }
 refkit_image_patch_os_release[vardepsexclude] = " \
-    DISTRO_VERSION \
     BUILD_ID \
 "
 ROOTFS_POSTPROCESS_COMMAND += "refkit_image_patch_os_release; "

--- a/meta-refkit/conf/distro/refkit.conf
+++ b/meta-refkit/conf/distro/refkit.conf
@@ -3,10 +3,9 @@ DISTRO_NAME = "IoT Reference OS Kit for Intel(r) Architecture"
 # The version is bumped after each official release.
 # This implies that new releases go out with a version
 # string based on the predecessor plus the suffix
-DISTRO_VERSION = "1.0+snapshot-${DATE}"
-DISTRO_VERSION[vardepsexclude] = "DATE"
+DISTRO_VERSION ?= "refkit.0"
 SDK_VENDOR = "-refkitsdk"
-SDK_VERSION := "${@'${DISTRO_VERSION}'.replace('snapshot-${DATE}','snapshot')}"
+SDK_VERSION := "refkit.0"
 SDK_NAME_PREFIX = "refkit"
 
 # Set custom tasks from IoT Reference OS Kit layers as recursive dependencies to do_populate_sdk.

--- a/meta-refkit/recipes-core/os-release/os-release.bbappend
+++ b/meta-refkit/recipes-core/os-release/os-release.bbappend
@@ -1,9 +1,7 @@
 # In IoT Reference OS Kit We only put mostly static values into the os-release
 # package. That avoids unnecessary recompilations.  Dynamic values
-# like DISTRO_VERSION (which in our case contain ${DATE}) and BUILD_ID
-# (includes ${DATETIME}) get patched to the current values in
+# like BUILD_ID (includes ${DATETIME}) get patched to the current values in
 # refkit-image.bbclass.
 
-DISTRO_VERSION = "distro-version-to-be-added-during-image-creation"
 BUILD_ID = "build-id-to-be-added-during-image-creation"
 OS_RELEASE_FIELDS += "BUILD_ID"


### PR DESCRIPTION
Currently, our DISTRO_VERSION is set to a misleading value and is not even
updated regularly. As we are working in a (partially) rolling-release mode,
any "point release" versioning does not make much sense.

Use static DISTRO_VERSION that gives no indication of any specific version.

Signed-off-by: Mikko Ylinen <mikko.ylinen@linux.intel.com>