### PR TITLE
remove swupd tweaks from default build

### DIFF
--- a/meta-refkit/classes/refkit-image.bbclass
+++ b/meta-refkit/classes/refkit-image.bbclass
@@ -160,20 +160,6 @@ export ALTERNATIVE_PRIORITY_UTIL_LINUX ?= "305"
 # just mount/umount as overrides for Toybox/Busybox.
 IMAGE_INSTALL += "util-linux"
 
-# We need "login" and "passwd" from shadow because:
-# - Busybox "login" does not use PAM and thus would require
-#   separate patching to support stateless motd (patched
-#   in libpam); also the login via getty is different compared
-#   to logins via ssh, which is potentially confusing and thus
-#   should better be avoided (either no PAM, or PAM everywhere).
-# - /dev/tty does not point to the serial console when logging
-#   in via getty and using Busybox login, so anything that
-#   tries to interact with the user (passwd, ssh) fails.
-# - shadow "passwd" creates /etc/shadow if it does not exist
-#   yet (required when setting the root password).
-export ALTERNATIVE_PRIORITY_SHADOW ?= "305"
-IMAGE_INSTALL += "shadow"
-
 # Common profile has "packagegroup-common-test" that has packages that are
 # used only in "development" configuration.
 FEATURE_PACKAGES_common-test = "packagegroup-common-test"

--- a/meta-refkit/classes/refkit-image.bbclass
+++ b/meta-refkit/classes/refkit-image.bbclass
@@ -106,8 +106,8 @@ IMAGE_INSTALL_append = "${@ ' efi-combo-trigger' if ${REFKIT_USE_DSK_IMAGES} and
 # Setting a label explicitly on the directory prevents it
 # from inheriting other undesired attributes like security.SMACK64TRANSMUTE
 # from upper folders (see xattr-images.bbclass for details).
-DEPENDS_${PN}_append = " \
-    ${@ bb.utils.contains('IMAGE_FEATURES', 'swupd', 'xattr-native', '', d)} \
+DEPENDS_append = " \
+    ${@ bb.utils.contains('IMAGE_FEATURES', 'swupd', 'attr-native', '', d)} \
 "
 fix_var_lib_swupd () {
     if ${@bb.utils.contains('IMAGE_FEATURES', 'smack', 'true', 'false', d)} &&

--- a/meta-refkit/classes/refkit-image.bbclass
+++ b/meta-refkit/classes/refkit-image.bbclass
@@ -237,17 +237,6 @@ FEATURE_PACKAGES_tools-debug_append = " valgrind"
 FEATURE_PACKAGES_computervision = "packagegroup-computervision"
 FEATURE_PACKAGES_computervision-test = "packagegroup-computervision-test"
 
-# We could make bash the login shell for interactive accounts as shown
-# below, but that would have to be done also in the os-core and thus
-# tools-interactive would have to be set in all swupd images.
-# TODO (?): introduce a bash-login-shell image feature?
-# ROOTFS_POSTPROCESS_COMMAND_append = "${@bb.utils.contains('IMAGE_FEATURES', 'tools-interactive', ' root_bash_shell; ', '', d)}"
-# root_bash_shell () {
-#     sed -i -e 's;/bin/sh;/bin/bash;' \
-#        ${IMAGE_ROOTFS}${sysconfdir}/passwd \
-#        ${IMAGE_ROOTFS}${sysconfdir}/default/useradd
-# }
-
 IMAGE_LINGUAS = " "
 
 LICENSE = "MIT"

--- a/meta-refkit/classes/refkit-image.bbclass
+++ b/meta-refkit/classes/refkit-image.bbclass
@@ -93,72 +93,11 @@ python () {
 }
 def refkit_swupd_image_class(d):
     if 'swupd' in d.getVar('IMAGE_FEATURES').split() and d.getVar('LAYERVERSION_meta-swupd'):
-        return 'swupd-image'
+        return 'refkit-swupd-image'
     else:
         return ''
+# Here we optionally inherit refkit-swupd-image.bbclass, which configures and activates swupd.
 inherit ${@refkit_swupd_image_class(d)}
-
-# Activate support for updating EFI system partition when using
-# both meta-swupd and the EFI kernel+initramfs combo.
-IMAGE_INSTALL_append = "${@ ' efi-combo-trigger' if ${REFKIT_USE_DSK_IMAGES} and 'swupd' in d.getVar('IMAGE_FEATURES').split() else '' }"
-
-# Workaround when both Smack and swupd are used:
-# Setting a label explicitly on the directory prevents it
-# from inheriting other undesired attributes like security.SMACK64TRANSMUTE
-# from upper folders (see xattr-images.bbclass for details).
-DEPENDS_append = " \
-    ${@ bb.utils.contains('IMAGE_FEATURES', 'swupd', 'attr-native', '', d)} \
-"
-fix_var_lib_swupd () {
-    if ${@bb.utils.contains('IMAGE_FEATURES', 'smack', 'true', 'false', d)} &&
-       ${@bb.utils.contains('IMAGE_FEATURES', 'swupd', 'true', 'false', d)}; then
-        install -d ${IMAGE_ROOTFS}/var/lib/swupd
-        setfattr -n security.SMACK64 -v "_" ${IMAGE_ROOTFS}/var/lib/swupd
-    fi
-}
-ROOTFS_POSTPROCESS_COMMAND_append = " fix_var_lib_swupd;"
-
-# Make progress messages from do_swupd_update visible as normal command
-# line output, instead of just recording it to the logs. Useful
-# because that task can run for a long time without any output.
-SWUPD_LOG_FN ?= "bbplain"
-
-# When using the "swupd" image feature, ensure that OS_VERSION is
-# set as intended. The default for local build works, but yields very
-# unpredictable version numbers (see refkit.conf for details).
-#
-# For example, build with:
-#   BB_ENV_EXTRAWHITE="$BB_ENV_EXTRAWHITE OS_VERSION" OS_VERSION=100 bitbake refkit-image-common
-#   ...
-
-# Customize priorities of alternative components. See refkit.conf.
-#
-# In general, Busybox or Toybox are preferred over alternatives.
-# The expectation is that either Busybox or Toybox are used, but if
-# both get installed, Toybox is used for those commands that it
-# provides.
-#
-# It is still possible to build images with coreutils providing
-# core system tools, one just has to remove Toybox/Busybox from
-# the image.
-export ALTERNATIVE_PRIORITY_BUSYBOX ?= "300"
-export ALTERNATIVE_PRIORITY_TOYBOX ?= "301"
-export ALTERNATIVE_PRIORITY_BASH ?= "305"
-
-# Both systemd and the efi_combo_updater have problems when
-# "mount" is provided by busybox: systemd fails to remount
-# the rootfs read/write and the updater segfaults because
-# it does not parse the output correctly.
-#
-# For now avoid these problems by sticking to the traditional
-# mount utilities from util-linux.
-export ALTERNATIVE_PRIORITY_UTIL_LINUX ?= "305"
-
-# We do not know exactly which util-linux packages will get
-# pulled into bundles, so we have to install all of them
-# also in the os-core. Alternatively we could try to select
-# just mount/umount as overrides for Toybox/Busybox.
-IMAGE_INSTALL += "util-linux"
 
 # Common profile has "packagegroup-common-test" that has packages that are
 # used only in "development" configuration.

--- a/meta-refkit/classes/refkit-swupd-image.bbclass
+++ b/meta-refkit/classes/refkit-swupd-image.bbclass
@@ -60,9 +60,4 @@ export ALTERNATIVE_PRIORITY_BASH ?= "305"
 # For now avoid these problems by sticking to the traditional
 # mount utilities from util-linux.
 export ALTERNATIVE_PRIORITY_UTIL_LINUX ?= "305"
-
-# We do not know exactly which util-linux packages will get
-# pulled into bundles, so we have to install all of them
-# also in the os-core. Alternatively we could try to select
-# just mount/umount as overrides for Toybox/Busybox.
-IMAGE_INSTALL += "util-linux"
+IMAGE_INSTALL += "util-linux-mount"

--- a/meta-refkit/classes/refkit-swupd-image.bbclass
+++ b/meta-refkit/classes/refkit-swupd-image.bbclass
@@ -47,8 +47,9 @@ SWUPD_LOG_FN ?= "bbplain"
 # core system tools, one just has to remove Toybox/Busybox from
 # the image.
 export ALTERNATIVE_PRIORITY_BUSYBOX ?= "250"
-# systemd is at 300 and must be higher than busybox for the "halt" command
-export ALTERNATIVE_PRIORITY_TOYBOX ?= "301"
+export ALTERNATIVE_PRIORITY_TOYBOX ?= "280"
+# systemd has priority 300, busybox must have less because
+# we want halt/poweroff/reboot from systemd
 export ALTERNATIVE_PRIORITY_BASH ?= "305"
 
 # Both systemd and the efi_combo_updater have problems when
@@ -58,7 +59,7 @@ export ALTERNATIVE_PRIORITY_BASH ?= "305"
 #
 # For now avoid these problems by sticking to the traditional
 # mount utilities from util-linux.
-export ALTERNATIVE_PRIORITY_UTIL_LINUX ?= "306"
+export ALTERNATIVE_PRIORITY_UTIL_LINUX ?= "305"
 
 # We do not know exactly which util-linux packages will get
 # pulled into bundles, so we have to install all of them

--- a/meta-refkit/classes/refkit-swupd-image.bbclass
+++ b/meta-refkit/classes/refkit-swupd-image.bbclass
@@ -1,0 +1,67 @@
+# Meant to be inherited by refkit-image.bbclass if, and only if,
+# swupd is enabled as an image feature. Contains the swupd-specific
+# image settings.
+
+inherit swupd-image
+
+# Activate support for updating EFI system partition when using
+# both meta-swupd and the EFI kernel+initramfs combo.
+IMAGE_INSTALL_append = "${@ ' efi-combo-trigger' if ${REFKIT_USE_DSK_IMAGES} else '' }"
+
+# Workaround when both Smack and swupd are used:
+# Setting a label explicitly on the directory prevents it
+# from inheriting other undesired attributes like security.SMACK64TRANSMUTE
+# from upper folders (see xattr-images.bbclass for details).
+DEPENDS_append = " \
+    ${@ bb.utils.contains('IMAGE_FEATURES', 'swupd', 'attr-native', '', d)} \
+"
+fix_var_lib_swupd () {
+    if ${@bb.utils.contains('IMAGE_FEATURES', 'smack', 'true', 'false', d)}; then
+        install -d ${IMAGE_ROOTFS}/var/lib/swupd
+        setfattr -n security.SMACK64 -v "_" ${IMAGE_ROOTFS}/var/lib/swupd
+    fi
+}
+ROOTFS_POSTPROCESS_COMMAND_append = " fix_var_lib_swupd;"
+
+# Make progress messages from do_swupd_update visible as normal command
+# line output, instead of just recording it to the logs. Useful
+# because that task can run for a long time without any output.
+SWUPD_LOG_FN ?= "bbplain"
+
+# When using the "swupd" image feature, ensure that OS_VERSION is
+# set as intended. The default for local build works, but yields very
+# unpredictable version numbers (see refkit.conf for details).
+#
+# For example, build with:
+#   BB_ENV_EXTRAWHITE="$BB_ENV_EXTRAWHITE OS_VERSION" OS_VERSION=100 bitbake refkit-image-common
+#   ...
+
+# Customize priorities of alternative components. See refkit.conf.
+#
+# In general, Busybox or Toybox are preferred over alternatives.
+# The expectation is that either Busybox or Toybox are used, but if
+# both get installed, Toybox is used for those commands that it
+# provides.
+#
+# It is still possible to build images with coreutils providing
+# core system tools, one just has to remove Toybox/Busybox from
+# the image.
+export ALTERNATIVE_PRIORITY_BUSYBOX ?= "250"
+# systemd is at 300 and must be higher than busybox for the "halt" command
+export ALTERNATIVE_PRIORITY_TOYBOX ?= "301"
+export ALTERNATIVE_PRIORITY_BASH ?= "305"
+
+# Both systemd and the efi_combo_updater have problems when
+# "mount" is provided by busybox: systemd fails to remount
+# the rootfs read/write and the updater segfaults because
+# it does not parse the output correctly.
+#
+# For now avoid these problems by sticking to the traditional
+# mount utilities from util-linux.
+export ALTERNATIVE_PRIORITY_UTIL_LINUX ?= "306"
+
+# We do not know exactly which util-linux packages will get
+# pulled into bundles, so we have to install all of them
+# also in the os-core. Alternatively we could try to select
+# just mount/umount as overrides for Toybox/Busybox.
+IMAGE_INSTALL += "util-linux"

--- a/meta-refkit/wic/refkit-directdisk.wks.in
+++ b/meta-refkit/wic/refkit-directdisk.wks.in
@@ -7,3 +7,4 @@ bootloader --ptable gpt
 part --source rootfs --rootfs-dir=${IMAGE_ROOTFS}/boot --fstype=vfat --fixed-size ${REFKIT_VFAT_MB}M --label primary_uefi --part-type C12A7328-F81F-11D2-BA4B-00A0C93EC93B --align 1024 --use-uuid
 part --source rootfs --rootfs-dir=${IMAGE_ROOTFS}/boot --fstype=vfat --fixed-size ${REFKIT_VFAT_MB}M --label secondary_uefi --part-type E3C9E316-0B5C-4DB8-817D-F92DF00215AF --align 1024 --use-uuid
 part / --source rootfs ${REFKIT_IMAGE_SIZE} --fstype=ext4 --label rootfs --align 1024 --uuid ${REMOVABLE_MEDIA_ROOTFS_PARTUUID_VALUE}
+${REFKIT_EXTRA_PARTITION}


### PR DESCRIPTION
We don't even have meta-swupd in refkit, so it makes more sense to
leave distro settings at their defaults instead of enabling
swupd-related tweaks in all cases.