### PR TITLE
refkit-image: move iotivity out from common

### DIFF
--- a/meta-iotqa/conf/test/refkit-image-common.manifest
+++ b/meta-iotqa/conf/test/refkit-image-common.manifest
@@ -7,6 +7,5 @@ oeqa.runtime.sanity.comm_wifi_connect
 oeqa.runtime.sanity.apprt_python
 oeqa.runtime.sanity.mraa_hello
 oeqa.runtime.sanity.mraa_gpio
-oeqa.runtime.sanity.iotivity
 oeqa.runtime.alsa.alsa
 oeqa.runtime.sanity.upm

--- a/meta-iotqa/conf/test/refkit-image-gateway.manifest
+++ b/meta-iotqa/conf/test/refkit-image-gateway.manifest
@@ -1,3 +1,4 @@
 # Tests for gateway profile
 oeqa.runtime.sanity.apprt_nodejs
+oeqa.runtime.sanity.iotivity
 oeqa.runtime.sanity.pulseaudio

--- a/meta-refkit/classes/refkit-image.bbclass
+++ b/meta-refkit/classes/refkit-image.bbclass
@@ -112,7 +112,6 @@ FEATURE_PACKAGES_common-test = "packagegroup-common-test"
 REFKIT_IMAGE_FEATURES_COMMON ?= " \
     connectivity \
     ssh-server-openssh \
-    iotivity \
     alsa \
     sensors \
 "


### PR DESCRIPTION
iotivity is not something all profile images need to share.
Keep it in gateway for now and move it out from common.

Signed-off-by: Mikko Ylinen <mikko.ylinen@linux.intel.com>