### PR TITLE
refkit images: mount read/write by default

### DIFF
--- a/meta-refkit/classes/refkit-image.bbclass
+++ b/meta-refkit/classes/refkit-image.bbclass
@@ -292,9 +292,10 @@ REFKIT_IMAGE_STRIP_SMACK = "${@ 'refkit_image_strip_smack' if not bb.utils.conta
 do_rootfs[postfuncs] += "${REFKIT_IMAGE_STRIP_SMACK}"
 DEPENDS += "${@ 'attr-native' if '${REFKIT_IMAGE_STRIP_SMACK}' else '' }"
 
-# Mount read-only at first. This gives systemd a chance to run fsck
-# and then mount read/write.
-APPEND_append = " ro"
+# Disable running fsck at boot. System clock is typically wrong at early boot
+# stage due to lack of RTC backup battery. This causes unnecessary fixes being
+# made due to filesystem metadata time stamps being in future.
+APPEND_append = " fsck.mode=skip"
 
 # Ensure that images preserve Smack labels and IMA/EVM.
 inherit ${@bb.utils.contains_any('IMAGE_FEATURES', ['ima','smack'], 'xattr-images', '', d)}

--- a/meta-refkit/conf/distro/refkit.conf
+++ b/meta-refkit/conf/distro/refkit.conf
@@ -308,8 +308,3 @@ PACKAGE_ARCH_pn-rhino = "${TUNE_PKGARCH}"
 # re-use uninative shim released by Yocto Project / OE
 require conf/distro/include/yocto-uninative.inc
 INHERIT += "uninative"
-
-# Disable running fsck at boot. System clock is typically wrong at early boot
-# stage due to lack of RTC backup battery. This causes unnecessary fixes being
-# made due to filesystem metadata time stamps being in future.
-APPEND_append = " fsck.mode=skip"


### PR DESCRIPTION
Mounting as read-only was enforced with the argument that then
fsck can be applied to the rootfs, but exactly that was explicitly
disabled in the distro configuration.

Disabling fsck makes sense, but that is better set in the image class,
and then we can also directly mount rw (avoids a remount, better for a
stateless image, for example because we don't need the empty
/etc/machine-id).

Signed-off-by: Patrick Ohly <patrick.ohly@intel.com>