### PR TITLE
Reduce Python 3 dependencies

### DIFF
--- a/meta-refkit/conf/distro/refkit.conf
+++ b/meta-refkit/conf/distro/refkit.conf
@@ -71,6 +71,9 @@ PACKAGECONFIG_remove_pn-gstreamer1.0-plugins-base = "pango"
 
 PACKAGECONFIG_remove_pn-pulseaudio = "avahi"
 
+# leave out readline, gdbm, and db
+PACKAGECONFIG_pn-python3 = ""
+
 # since we have OpenCL support, turn it on
 PACKAGECONFIG_append_pn-opencv = " opencl"
 PREFERRED_PROVIDER_virtual/opencl-headers = "opencl-headers"

--- a/meta-refkit/recipes-devtools/python/python3_%.bbappend
+++ b/meta-refkit/recipes-devtools/python/python3_%.bbappend
@@ -1,0 +1,13 @@
+DEPENDS_remove = "readline gdbm db"
+
+PACKAGECONFIG ??= "readline gdbm db"
+PACKAGECONFIG[readline] = ",,readline"
+PACKAGECONFIG[gdbm] = ",,gdbm"
+PACKAGECONFIG[db] = ",,db"
+
+RRECOMMENDS_${PN}-core = "${@bb.utils.contains('PACKAGECONFIG', 'readline', '${PN}-readline', '', d)}"
+
+# if readline is not there, don't create python3-readline package
+PACKAGES_remove += "${@bb.utils.contains('PACKAGECONFIG', 'readline', '', '${PN}-readline', d)}"
+PROVIDES_remove += "${@bb.utils.contains('PACKAGECONFIG', 'readline', '', '${PN}-readline', d)}"
+RDEPENDS_${PN}-modules_remove += "${@bb.utils.contains('PACKAGECONFIG', 'readline', '', '${PN}-readline', d)}"


### PR DESCRIPTION
Compile Python 3 without readline, gdbm, and db support. This removes the need for GPLv3 depedencies.

The patch was submitted upstream (https://patchwork.openembedded.org/patch/136368/) but never merged. This is the `.bbappend` version of it.