### PR TITLE
Remove readline support from bluez5

### DIFF
--- a/meta-refkit/conf/distro/refkit.conf
+++ b/meta-refkit/conf/distro/refkit.conf
@@ -69,6 +69,9 @@ PACKAGECONFIG_pn-python3-pygobject ?= ""
 # pango, a graphical text rendering library, is not needed by us.
 PACKAGECONFIG_remove_pn-gstreamer1.0-plugins-base = "pango"
 
+# remove readline support from Bluez to reduce GPLv3 dependencies
+BAD_RECOMMENDATIONS += "bluez5-client"
+
 PACKAGECONFIG_remove_pn-pulseaudio = "avahi"
 
 # leave out readline, gdbm, and db

--- a/meta-refkit/recipes-connectivity/bluez5/bluez5_5%.bbappend
+++ b/meta-refkit/recipes-connectivity/bluez5/bluez5_5%.bbappend
@@ -1,2 +1,7 @@
 # libusb is not required. This removes dependency on libusb-compat.
 DEPENDS_remove = "libusb"
+
+# split bluetoothctl into a subpackage
+PACKAGES =+ "${PN}-client"
+FILES_${PN}-client = "${@bb.utils.contains('PACKAGECONFIG', 'readline', '${bindir}/bluetoothctl', '', d)}"
+RRECOMMENDS_${PN} += "${PN}-client"


### PR DESCRIPTION
The reason behind this is to eventually remove libreadline from our images with production configuration.