### PR TITLE
buildhistory-extra.bbclass: allow expansion of S and BASE_WORKDIR

### DIFF
--- a/meta-refkit/classes/buildhistory-extra.bbclass
+++ b/meta-refkit/classes/buildhistory-extra.bbclass
@@ -37,13 +37,18 @@ python buildhistory_extra_emit_pkghistory() {
     if not os.path.exists(pkghistdir):
         bb.utils.mkdirhier(pkghistdir)
 
-    # Make the recorded information independent of varying paths.
-    # Some recipes use destsuffix=${S}/... to fetch components
+    # Make the recorded information independent of varying paths
+    # by replacing with the name of the variable. We have to have
+    # some value, otherwise expanding certain expressions fails
+    # entirely, for example in ovmf_git.bb:
+    # ${@bb.utils.contains('PACKAGECONFIG', 'secureboot', 'http://www.openssl.org/source/openssl-1.0.2j.tar.gz;name=openssl;subdir=${S}/CryptoPkg/Library/OpensslLib', '', d)}
+    #
+    # Some recipes also use destsuffix=${S}/... to fetch components
     # into their main source tree. The other variable do not show
     # up (yet), but might eventually.
     d = d.createCopy()
     for var in ('S', 'BASE_WORKDIR'):
-        d.delVar(var)
+        d.setVar(var, var)
     relpath = os.path.dirname(d.getVar('TOPDIR', True))
 
     # Record PV in the "latest" file. This duplicates work in


### PR DESCRIPTION
The previous approach of leaving ${S} and ${BASE_WORKDIR} unchanged in
source URLs fails for ovmf which embedds ${S} in a more complex
expression:
    ${@bb.utils.contains('PACKAGECONFIG', 'secureboot', 'http://www.openssl.org/source/openssl-1.0.2j.tar.gz;name=openssl;subdir=${S}/CryptoPkg/Library/OpensslLib', '', d)}

When expanding ${S} fails because it is unset, the entire expression
is left unexpanded, which then causes parser errors because it isn't
a valid URL.

So instead, now we replace ${S} with S, leading to entries in the
build history like this:
    http://www.openssl.org/source/openssl-1.0.2j.tar.gz;name=openssl;subdir=S/CryptoPkg/Library/OpensslLib intel-corei7-64/downloads/openssl-1.0.2j.tar.gz e7aff292be21c259c6af26469c7a9b3ba26e9abaaffd325e3dccc9785256c431

Same for BASE_WORKDIR.

Signed-off-by: Patrick Ohly <patrick.ohly@intel.com>