### PR TITLE
[TEST] CI: Use USB stick emulation instead of flashing image

### DIFF
--- a/docker/tester-exec.sh
+++ b/docker/tester-exec.sh
@@ -73,7 +73,7 @@ testimg() {
   # Execute with +e to make sure that possibly created log files get
   # renamed, archived, published even when AFT or some of renaming fails
   set +e
-  daft ${DEVICE} ${FILENAME} --record
+  daft ${DEVICE} ${FILENAME} --record --emulateusb
   AFT_EXIT_CODE=$?
 
   # modify names inside TEST-*.xml files to contain device and img_name

--- a/meta-refkit/classes/refkit-image.bbclass
+++ b/meta-refkit/classes/refkit-image.bbclass
@@ -230,7 +230,7 @@ NOHDD = "1"
 # Image creation: add here the desired value for the PARTUUID of
 # the rootfs. WARNING: any change to this value will trigger a
 # rebuild (and re-sign, if enabled) of the combo EFI application.
-REMOVABLE_MEDIA_ROOTFS_PARTUUID_VALUE = "12345678-9abc-def0-0fed-cba987654321"
+REMOVABLE_MEDIA_ROOTFS_PARTUUID_VALUE = "12345678-9abc-def0-0fed-cba987654329"
 # The second value is needed for the system installed onto
 # the device's internal storage in order to mount correct rootfs
 # when an installation media is still inserted into the device.


### PR DESCRIPTION
Instead of flashing the image to internal memory or sd card, use
BeagleBones USB mass storage emulation to boot the image and test it.
This will be much faster as no flashing needs to be done. There is a problem
with booting if both the internal memory and the USB emulation has same
rootfs disk uuid, so change it for testing purposes. If this will be used test device
internal memory or sd card can be just written over so uuid doesn't have to be
changed.

Signed-off-by: Simo Kuusela <simo.kuusela@intel.com>