### PR TITLE
meta-iotqa: After Bluetooth test disable Bluetooth

### DIFF
--- a/meta-iotqa/lib/oeqa/runtime/sanity/comm_btcheck.py
+++ b/meta-iotqa/lib/oeqa/runtime/sanity/comm_btcheck.py
@@ -8,6 +8,14 @@ class CommBluetoothTest(oeRuntimeTest):
     @class CommBluetoothTest
     """
     log = ""
+
+    def setUp(self):
+        self.target.run('connmanctl enable bluetooth')
+        time.sleep(8)
+
+    def tearDown(self):
+        self.target.run('connmanctl disable bluetooth')
+
     def target_collect_info(self, cmd):
         """
         @fn target_collect_info
@@ -29,8 +37,6 @@ class CommBluetoothTest(oeRuntimeTest):
         # un-block software rfkill lock
         self.target.run('rfkill unblock all')
         # This is special for edison platform
-        self.target.run('connmanctl enable bluetooth')
-        time.sleep(8)
         # Collect system information as log
         self.target_collect_info("ifconfig")
         self.target_collect_info("hciconfig")

--- a/meta-iotqa/lib/oeqa/runtime/sanity/comm_btcheck.py
+++ b/meta-iotqa/lib/oeqa/runtime/sanity/comm_btcheck.py
@@ -34,9 +34,6 @@ class CommBluetoothTest(oeRuntimeTest):
         @param self
         @return
         '''
-        # un-block software rfkill lock
-        self.target.run('rfkill unblock all')
-        # This is special for edison platform
         # Collect system information as log
         self.target_collect_info("ifconfig")
         self.target_collect_info("hciconfig")


### PR DESCRIPTION
At the start of Bluetooth testing, Bluetooth is getting enabled so after
tests are done it should be disabled again so it doesn't interfere with
other tests. For some reason WiFi test takes about 2 minutes longer with
Minnowboard if Bluetooth isn't disabled after Bluetooth test is done.
Also remove a command that is only for Edison (which isn't supported).

Signed-off-by: Simo Kuusela <simo.kuusela@intel.com>