### PR TITLE
CI publish-project: handle isafw logs,reports better

### DIFF
--- a/docker/publish-project.sh
+++ b/docker/publish-project.sh
@@ -98,10 +98,16 @@ if [ -d ${_DEPL}/testsuite ]; then
     create_remote_dirs ${_RSYNC_DEST} testsuite/${TARGET_MACHINE}
     rsync -av ${_DEPL}/testsuite/* ${_RSYNC_DEST}/testsuite/${TARGET_MACHINE}/
 fi
-# publish isafw reports
+# publish isafw reports and logs
 if [ -n "$(find ${_BRESULT}/log -maxdepth 1 -name 'isafw*' -print -quit)" ]; then
     create_remote_dirs ${_RSYNC_DEST} isafw/${TARGET_MACHINE}/
-    rsync -avz ${_BRESULT}/log/isafw-report*/* ${_RSYNC_DEST}/isafw/${TARGET_MACHINE}/ --exclude internal
+    if [ -n "$(find ${_BRESULT}/log -maxdepth 1 -name 'isafw-logs' -print -quit)" ]; then
+        rsync -avz ${_BRESULT}/log/isafw-logs/* ${_RSYNC_DEST}/isafw/${TARGET_MACHINE}/ --exclude internal
+    fi
+    # isafw reports are created in timestamp-named subdirs like isafw-report_20170409070145/
+    if [ -n "$(find ${_BRESULT}/log -maxdepth 1 -name 'isafw-report*' -print -quit)" ]; then
+        rsync -avz ${_BRESULT}/log/isafw-report*/* ${_RSYNC_DEST}/isafw/${TARGET_MACHINE}/ --exclude internal
+    fi
 fi
 
 LOG="$WORKSPACE/bitbake-${TARGET_MACHINE}-${CI_BUILD_ID}.log"


### PR DESCRIPTION
Publish script failed if isafw-logs/ was present but
isafw-reports dirs were not yet created, added proper
checks and publish for both parts.
Note: this adds publish of isafw logs, which we did not
publish before.

Signed-off-by: Olev Kartau <olev.kartau@intel.com>