### PR TITLE
meta-refkit: Add test to check qemu

### DIFF
--- a/meta-refkit/lib/oeqa/selftest/refkit/runqemu.py
+++ b/meta-refkit/lib/oeqa/selftest/refkit/runqemu.py
@@ -39,16 +39,6 @@ class RunqemuTests(oeSelfTest):
         self.ovmf_recipe = 'ovmf'
         self.cmd_common = "runqemu ovmf wic slirp nographic serial"
 
-        # Avoid emit the same record multiple times.
-        mainlogger = logging.getLogger("BitBake.Main")
-        mainlogger.propagate = False
-
-        self.write_config(
-"""
-# 10 means 1 second
-SYSLINUX_TIMEOUT = "10"
-""")
-
         if not RunqemuTests.image_is_ready:
             RunqemuTests.deploy_dir_image = get_bb_var('DEPLOY_DIR_IMAGE')
             bitbake(self.refkit_recipe)

--- a/meta-refkit/lib/oeqa/selftest/refkit/runqemu.py
+++ b/meta-refkit/lib/oeqa/selftest/refkit/runqemu.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+# ex:ts=4:sw=4:sts=4:et
+# -*- tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*-
+#
+# Copyright (c) 2017, Intel Corporation.
+# All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# AUTHORS
+# Humberto Ibarra <humberto.ibarra.lopez@linux.intel.com>
+
+import re
+import logging
+
+from oeqa.selftest.base import oeSelfTest
+from oeqa.utils.commands import bitbake, runqemu, get_bb_var
+from oeqa.utils.decorators import testcase
+
+class RunqemuTests(oeSelfTest):
+    """Runqemu test class"""
+
+    image_is_ready = False
+    deploy_dir_image = ''
+
+    def setUpLocal(self):
+        self.refkit_recipe = 'refkit-image-common'
+        self.ovmf_recipe = 'ovmf'
+        self.cmd_common = "runqemu ovmf wic slirp nographic serial"
+
+        # Avoid emit the same record multiple times.
+        mainlogger = logging.getLogger("BitBake.Main")
+        mainlogger.propagate = False
+
+        self.write_config(
+"""
+# 10 means 1 second
+SYSLINUX_TIMEOUT = "10"
+""")
+
+        if not RunqemuTests.image_is_ready:
+            RunqemuTests.deploy_dir_image = get_bb_var('DEPLOY_DIR_IMAGE')
+            bitbake(self.refkit_recipe)
+            bitbake(self.ovmf_recipe)
+            RunqemuTests.image_is_ready = True
+
+    @testcase(2001)
+    def test_boot_machine(self):
+        """Test runqemu machine"""
+        with runqemu(self.refkit_recipe, ssh=False, launch_cmd=self.cmd_common) as qemu:
+            self.assertTrue(qemu.runner.logged, "Failed: %s" % self.cmd_common)


### PR DESCRIPTION
Add a basic test to check that qemu runs with refkit. Based on
Yocto bug #11203. The test is to be add in a selftest/refkit
path, so it could be run with:

oe-selftest -r refkit.runqemu.RunqemuTests.test_boot_machine

Further selftest tests can be added in the refkit folder. Considering
this, running all refkit selftest tests could be easily done with:

oe-selftest --run-tests-by module refkit.*

Signed-off-by: Humberto Ibarra <humberto.ibarra.lopez@intel.com>