### PR TITLE
Configure Python2 to drop GPLv3 dependencies.

### DIFF
--- a/meta-refkit/conf/distro/refkit.conf
+++ b/meta-refkit/conf/distro/refkit.conf
@@ -76,6 +76,7 @@ PACKAGECONFIG_remove_pn-pulseaudio = "avahi"
 
 # leave out readline, gdbm, and db
 PACKAGECONFIG_pn-python3 = ""
+PACKAGECONFIG_pn-python ?= ""
 
 # since we have OpenCL support, turn it on
 PACKAGECONFIG_append_pn-opencv = " opencl"

--- a/meta-refkit/conf/distro/refkit.conf
+++ b/meta-refkit/conf/distro/refkit.conf
@@ -75,7 +75,7 @@ BAD_RECOMMENDATIONS += "bluez5-client"
 PACKAGECONFIG_remove_pn-pulseaudio = "avahi"
 
 # leave out readline, gdbm, and db
-PACKAGECONFIG_pn-python3 = ""
+PACKAGECONFIG_pn-python3 ?= ""
 PACKAGECONFIG_pn-python ?= ""
 
 # since we have OpenCL support, turn it on

--- a/meta-refkit/recipes-devtools/python/python_%.bbappend
+++ b/meta-refkit/recipes-devtools/python/python_%.bbappend
@@ -1,0 +1,13 @@
+DEPENDS_remove = "readline gdbm db"
+
+PACKAGECONFIG ??= "readline gdbm db"
+PACKAGECONFIG[readline] = ",,readline"
+PACKAGECONFIG[gdbm] = ",,gdbm"
+PACKAGECONFIG[db] = ",,db"
+
+RRECOMMENDS_${PN}-core = "${@bb.utils.contains('PACKAGECONFIG', 'readline', '${PN}-readline', '', d)}"
+
+# if readline is not there, don't create python-readline package
+PACKAGES_remove += "${@bb.utils.contains('PACKAGECONFIG', 'readline', '', '${PN}-readline', d)}"
+PROVIDES_remove += "${@bb.utils.contains('PACKAGECONFIG', 'readline', '', '${PN}-readline', d)}"
+RDEPENDS_${PN}-modules_remove += "${@bb.utils.contains('PACKAGECONFIG', 'readline', '', '${PN}-readline', d)}"


### PR DESCRIPTION
This is a temporary solution until https://github.com/intel/intel-iot-refkit/pull/109 is merged. The mechanism follows closely similar modification to Python3 in https://github.com/intel/intel-iot-refkit/pull/92.