### PR TITLE
CI Jenkinsfile: keep build workspaces with later off-build-path deletion

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -127,7 +127,7 @@ try {
         test_runs["test_${i}_${test_device}"] = {
             node('refkit-tester') {
                 deleteDir() // clean workspace
-                echo "Testing test_${test_device} with image_info: ${one_target_testinfo}"
+                echo "image_info: ${one_target_testinfo}"
                 writeFile file: 'tester-exec.sh', text: tester_script
                 writeFile file: 'run-qemu.exp', text: qemu_script
                 // append newline so that tester-exec.sh can parse it using "read"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ def current_project = "${env.JOB_NAME}".tokenize("_")[0]
 def image_name = "${current_project}_build:${env.BUILD_TAG}"
 def ci_build_id = "${env.BUILD_TIMESTAMP}-build-${env.BUILD_NUMBER}"
 def test_runs = [:]
-def testinfo_data = [:]
+def testinfo_data = ""
 def ci_git_commit = ""
 def global_sum_log = ""
 def added_commits = ""
@@ -93,7 +93,7 @@ try {
                 } // docker_image
                 tester_script = readFile "docker/tester-exec.sh"
                 qemu_script = readFile "docker/run-qemu.exp"
-                testinfo_data["${target_machine}"] = readFile "${target_machine}.testinfo.csv"
+                testinfo_data = readFile "${target_machine}.testinfo.csv"
                 if ( !is_pr ) {
                     ci_git_commit = readFile("ci_git_commit").trim()
                     // This command expects that each new master build is based on a github merge
@@ -118,7 +118,7 @@ try {
         }
     }
 
-    test_targets = testinfo_data["${target_machine}"].split("\n")
+    test_targets = testinfo_data.split("\n")
     for(int i = 0; i < test_targets.size() && test_targets[i] != ""; i++) {
         def one_target_testinfo = test_targets[i]
         def test_device = one_target_testinfo.split(',')[4]

--- a/docker/build-common-util.sh
+++ b/docker/build-common-util.sh
@@ -32,18 +32,21 @@ EOF
             # SSTATE over http
             echo "SSTATE_MIRRORS ?= \"file://.* ${COORD_BASE_URL}/bb-cache/sstate/PATH\"" >> conf/auto.conf
         fi
-        # Archiver set optionally: Product build has it, PR job does not.
-        if [ ! -z ${CI_ARCHIVER_MODE+x} ]; then
-            cat >> conf/auto.conf << EOF
+    else
+      # save sstate to workspace
+      echo "SSTATE_DIR = \"${BUILD_CACHE_DIR}/sstate\"" >> conf/auto.conf
+    fi
+}
+
+auto_conf_archiver() {
+    # Archiver set optionally: Product build has it, PR job does not.
+    if [ ! -z ${CI_ARCHIVER_MODE+x} ]; then
+        cat >> conf/auto.conf << EOF
 INHERIT += "archiver"
 ARCHIVER_MODE[src] = "original"
 ARCHIVER_MODE[diff] = "1"
 ARCHIVER_MODE[recipe] = "1"
 EOF
-        fi
-    else
-      # save sstate to workspace
-      echo "SSTATE_DIR = \"${BUILD_CACHE_DIR}/sstate\"" >> conf/auto.conf
     fi
 }
 

--- a/docker/build-project.sh
+++ b/docker/build-project.sh
@@ -57,6 +57,7 @@ fi
 
 # create auto.conf using functions in build-common-util.sh
 auto_conf_common
+auto_conf_archiver
 if [ ! -z ${JOB_NAME+x} ]; then
     # in CI run only:
     auto_conf_buildhistory

--- a/docker/post-build.sh
+++ b/docker/post-build.sh
@@ -38,10 +38,10 @@ for img in `grep REFKIT_CI_BUILD_TARGETS ${WORKSPACE}/refkit_ci_vars | perl -pe 
 done
 bitbake -S none ${_images}
 
-# Check intel-linux specifically in addition to images, because it did
+# Check linux-intel specifically in addition to images, because it did
 # rebuild at some point and even though bitbake-diffsigs should
 # recurse to it, that's not guaranteed to work.
-for target in intel-linux ${_images}; do
+for target in linux-intel ${_images}; do
   if ! bitbake-diffsigs -t $target do_build; then
     echo "$target: nothing changed or bitbake-diffsigs failed"
   fi
@@ -54,7 +54,7 @@ fi
 
 # If something changed during the oe-selftest setup, we should (finally)
 # have two signatures to compare here.
-for target in intel-linux ${_images}; do
+for target in linux-intel ${_images}; do
   if ! bitbake-diffsigs -t $target do_build; then
     echo "$target: nothing changed or bitbake-diffsigs failed"
   fi


### PR DESCRIPTION
"Keep workspaces" brings 2 improvements:
 - workspaces from few previous builds are present, allowing
   to check for state even after next build in same worker started;
 - deletion of older build trees does not take time of next build,
   it is performed by async-runned cleanup job.

Deletion of older workspaces is done after build in parallel with tester jobs,
scheduled in the same builder which performed build stage.

Additionally, this PR has smaller simplification in 1st commit,
2 simplifications related to single-MACHINE build in commits 4 and 5,
one status print shortening in commit 6,
one variable-defined-once improvement in commit 7.
Commits 8 and 9 deal with post-build test recently surfaced needs.