### PR TITLE
net-tools_%.bbappend: don't break class-target build.

### DIFF
--- a/meta-refkit/recipes-extended/net-tools/net-tools_%.bbappend
+++ b/meta-refkit/recipes-extended/net-tools/net-tools_%.bbappend
@@ -4,6 +4,7 @@ disable_i18n() {
        sed -i -e 's/^I18N=1/# I18N=1/' ${S}/config.make
 }
 disable_i18n_class-target () {
+  :
 }
 
 do_configure_append () {


### PR DESCRIPTION
Make the class target empty disable_i18n function more shell-friendly
by adding a shell-noop. Otherwise the build might abort with a shell
error along th elines of "error near unexpected token '}'".

Signed-off-by: Krisztian Litkey <krisztian.litkey@intel.com>