### PR TITLE
meta-security: update submodule to fix usrmerge

### DIFF
--- a/doc/howtos/image-install.rst
+++ b/doc/howtos/image-install.rst
@@ -134,7 +134,7 @@ machine. On a build host, create a build environment for building
 without Docker as explained in the :file:`README.rst`, then enter::
 
   $ export PATH=<path to intel-iot-refkit>/doc/howtos/image-installer:$PATH
-  $ bitbake refkit-installer-image ovmf swtpm-wrappers
+  $ bitbake refkit-installer-image ovmf swtpm-wrappers-native
   $ init-tpm
   $ runqemu-install # boots into shell prompt, there enter:
      # image-installer

--- a/meta-refkit/conf/distro/include/refkit-ci.inc
+++ b/meta-refkit/conf/distro/include/refkit-ci.inc
@@ -63,7 +63,7 @@ REFKIT_CI_POSTBUILD_SELFTESTS="image-installer"
 # Following targets would be used to perform default build task.
 # When adding new profile images, add them to refkit-installer-image.bb
 # and they will get pulled into the build indirectly.
-REFKIT_CI_BUILD_TARGETS="refkit-image-minimal refkit-installer-image swtpm-wrappers ovmf"
+REFKIT_CI_BUILD_TARGETS="refkit-image-minimal refkit-installer-image swtpm-wrappers-native ovmf"
 
 # Following targets would be executed with do_populate_sdk task
 REFKIT_CI_SDK_TARGETS=""

--- a/meta-refkit/conf/distro/refkit.conf
+++ b/meta-refkit/conf/distro/refkit.conf
@@ -348,10 +348,7 @@ PACKAGE_ARCH_pn-rhino = "${TUNE_PKGARCH}"
 require conf/distro/include/yocto-uninative.inc
 INHERIT += "uninative"
 
-# Temporary workaround for swtpm: SRCREV bump currently pending in meta-security master-next.
-SRCREV_pn-swtpm-native_forcevariable = "073e71f99eaa7a0ff9499339176af1af62c090b2"
-
 # Temporary workaround (needs to be fixed in meta-security once the
 # necessary patch "net-tools: enable native and nativesdk variant"
 # is in OE-core): swtpm_setup.sh needs netstat command.
-DEPENDS_append_pn-swtpm-wrappers = " net-tools-native"
+DEPENDS_append_pn-swtpm-wrappers-native = " net-tools-native"

--- a/meta-refkit/lib/oeqa/selftest/image-installer.py
+++ b/meta-refkit/lib/oeqa/selftest/image-installer.py
@@ -56,7 +56,7 @@ class ImageInstaller(oeSelfTest):
         # clean up which can result in the native tools built earlier in
         # setUpClass being unavailable.
         if not ImageInstaller.image_is_ready:
-            targets = 'refkit-installer-image ovmf swtpm-wrappers'
+            targets = 'refkit-installer-image ovmf swtpm-wrappers-native'
             print('Starting: bitbake %s' % targets)
             result = bitbake(targets)
             print(result.output)
@@ -81,7 +81,7 @@ class ImageInstaller(oeSelfTest):
         self.create_internal_disk()
 
         if tpm:
-            swtpm = glob('tmp-glibc/work/*/swtpm-wrappers/1.0-r0/swtpm_setup_oe.sh')
+            swtpm = glob('tmp-glibc/work/*/swtpm-wrappers-native/1.0-r0/swtpm_setup_oe.sh')
             self.assertEqual(len(swtpm), 1, msg='Expected exactly one swtpm_setup_oe.sh: %s' % swtpm)
             cmd = '%s --tpm-state %s --createek' % (swtpm[0], self.resultdir)
             self.assertEqual(0, runCmd(cmd).status)

--- a/meta-refkit/scripts/image-installer/init-tpm
+++ b/meta-refkit/scripts/image-installer/init-tpm
@@ -3,4 +3,4 @@
 IMAGE_DIR=tmp-glibc/deploy/images/intel-corei7-64
 rm -rf $IMAGE_DIR/my-tpm
 mkdir $IMAGE_DIR/my-tpm
-tmp-glibc/work/*/swtpm-wrappers/1.0-r0/swtpm_setup_oe.sh --tpm-state $IMAGE_DIR/my-tpm --createek
+tmp-glibc/work/*/swtpm-wrappers-native/1.0-r0/swtpm_setup_oe.sh --tpm-state $IMAGE_DIR/my-tpm --createek

--- a/meta-refkit/scripts/image-installer/runqemu-install
+++ b/meta-refkit/scripts/image-installer/runqemu-install
@@ -3,5 +3,5 @@
 IMAGE_DIR=tmp-glibc/deploy/images/intel-corei7-64
 truncate -s 4G $IMAGE_DIR/my-installed-image-intel-corei7-64.wic
 cp $IMAGE_DIR/refkit-installer-image-intel-corei7-64.qemuboot.conf $IMAGE_DIR/my-installed-image-intel-corei7-64.qemuboot.conf
-SWTPM=$(ls tmp-glibc/work/*/swtpm-wrappers/1.0-r0/swtpm_oe.sh)
+SWTPM=$(ls tmp-glibc/work/*/swtpm-wrappers-native/1.0-r0/swtpm_oe.sh)
 runqemu serial nographic refkit-installer-image wic intel-corei7-64 "qemuparams=-drive if=virtio,file=$IMAGE_DIR/my-installed-image-intel-corei7-64.wic,format=raw -tpmdev emulator,id=tpm0,spawn=on,tpmstatedir=$IMAGE_DIR/my-tpm,logfile=$IMAGE_DIR/my-tpm/swtpm.log,path=$SWTPM -device tpm-tis,tpmdev=tpm0" ovmf

--- a/meta-refkit/scripts/image-installer/runqemu-internal-disk
+++ b/meta-refkit/scripts/image-installer/runqemu-internal-disk
@@ -1,5 +1,5 @@
 #!/bin/sh -ex
 
 IMAGE_DIR=tmp-glibc/deploy/images/intel-corei7-64
-SWTPM=$(ls tmp-glibc/work/*/swtpm-wrappers/1.0-r0/swtpm_oe.sh)
+SWTPM=$(ls tmp-glibc/work/*/swtpm-wrappers-native/1.0-r0/swtpm_oe.sh)
 runqemu serial nographic my-installed-image wic intel-corei7-64 "qemuparams=-tpmdev emulator,id=tpm0,spawn=on,tpmstatedir=$IMAGE_DIR/my-tpm,logfile=$IMAGE_DIR/my-tpm/swtpm.log,path=$SWTPM -device tpm-tis,tpmdev=tpm0" ovmf


### PR DESCRIPTION
This fixes the problem with swtpm-wrappers and usrmerge by renaming it
to swtpm-wrappers-native. Not following that naming convention had
some real effect on DISTRO_FEATURE handling.

* meta-security 6674749...3bcca12 (4):
  > swtpm-wrappers: fix naming convention violation
  > tpm2.0-tss: update to tip.
  > samhain: update to 4.2.1
  > swtpm: update to latest tip

Signed-off-by: Patrick Ohly <patrick.ohly@intel.com>