### PR TITLE
meta-refkit-extra: move Boost package config to configuration file.

### DIFF
--- a/meta-refkit-extra/conf/distro/include/refkit-extra.conf
+++ b/meta-refkit-extra/conf/distro/include/refkit-extra.conf
@@ -4,3 +4,6 @@ SUPPORTED_RECIPES_append = " \
      ${META_REFKIT_EXTRA_BASE}/conf/distro/include/refkit-extra-supported-recipes.txt \
 "
 SUPPORTED_RECIPES[refkit-extra-supported-recipes.txt] = "extra"
+
+# Caffe needs Boost Python 3 bindings. Enable them in Boost.
+PACKAGECONFIG_append_pn-boost = " python"

--- a/meta-refkit-extra/recipes-convnet/boost/boost_%.bbappend
+++ b/meta-refkit-extra/recipes-convnet/boost/boost_%.bbappend
@@ -1,1 +1,0 @@
-PACKAGECONFIG += "python"


### PR DESCRIPTION
Do not have Boost PACKAGE_CONFIG variable set in a .bbappend file, because adding or removing layers should not affect the build result. Have the configuration setting instead in layer's distro config file.