### PR TITLE
compare sstate signatures between main build and post-build

### DIFF
--- a/docker/build-project.sh
+++ b/docker/build-project.sh
@@ -130,6 +130,10 @@ else
   _bitbake_targets="$BUILD_TARGET"
 fi
 
+# Ensure that we have a local sstate signature for all tasks, even those which do not need
+# to run. This makes it possible to investigate signature changes in post-build.sh.
+bitbake -S none ${_bitbake_targets}
+
 if [ ! -z ${JOB_NAME+x} ]; then
   # CI run: save output to log file
   LOG=$WORKSPACE/bitbake-${TARGET_MACHINE}-${CI_BUILD_ID}.log

--- a/docker/post-build.sh
+++ b/docker/post-build.sh
@@ -31,6 +31,22 @@ fi
 export BUILD_ID=${CI_BUILD_ID}
 export BB_ENV_EXTRAWHITE="$BB_ENV_EXTRAWHITE BUILD_ID"
 
+# Our post-build configuration should not require rebuilding.
+_images=""
+for img in `grep REFKIT_CI_BUILD_TARGETS ${WORKSPACE}/refkit_ci_vars | perl -pe 's/.+="(.*)"/\1/g; s/[^ a-zA-Z0-9_-]//g'`; do
+  _images="$_images ${img}"
+done
+bitbake -S none ${_images}
+
+# Check intel-linux specifically in addition to images, because it did
+# rebuild at some point and even though bitbake-diffsigs should
+# recurse to it, that's not guaranteed to work.
+for target in intel-linux ${_images}; do
+  if ! bitbake-diffsigs -t $target do_build; then
+    echo "$target: nothing changed or bitbake-diffsigs failed"
+  fi
+done
+
 _tests=`grep REFKIT_CI_POSTBUILD_SELFTESTS ${WORKSPACE}/refkit_ci_vars | perl -pe 's/.+="(.*)"/\1/g; s/[^ .a-zA-Z0-9_-]//g'`
 if [ -n "$_tests" ]; then
   oe-selftest --run-tests ${_tests}


### PR DESCRIPTION
We can check that the script changes do not break the build when
testing the PR, but we will have to merge and run a master build
before we'll know what's slowing down the master builds.