### PR TITLE
compare sstate signatures between main build and post-build, part II

### DIFF
--- a/docker/post-build.sh
+++ b/docker/post-build.sh
@@ -51,3 +51,11 @@ _tests=`grep REFKIT_CI_POSTBUILD_SELFTESTS ${WORKSPACE}/refkit_ci_vars | perl -p
 if [ -n "$_tests" ]; then
   oe-selftest --run-tests ${_tests}
 fi
+
+# If something changed during the oe-selftest setup, we should (finally)
+# have two signatures to compare here.
+for target in intel-linux ${_images}; do
+  if ! bitbake-diffsigs -t $target do_build; then
+    echo "$target: nothing changed or bitbake-diffsigs failed"
+  fi
+done


### PR DESCRIPTION
The previous attempt did not show anything useful from the time before
oe-selftest. Let's try also after the command.