### PR TITLE
Enable support for Wayland graphics

### DIFF
--- a/meta-refkit/conf/distro/include/refkit-core-wayland.inc
+++ b/meta-refkit/conf/distro/include/refkit-core-wayland.inc
@@ -1,0 +1,3 @@
+DISTRO_FEATURES_append = " wayland"
+DISTRO_FEATURES_append = " opengl"
+REFKIT_IMAGE_EXTRA_INSTALL_append = " weston weston-init"

--- a/meta-refkit/conf/distro/include/refkit-group
+++ b/meta-refkit/conf/distro/include/refkit-group
@@ -33,5 +33,6 @@ tty:x:5:
 users:x:978:
 utmp:x:987:
 video:x:979:
+weston-launch:x:976:
 wheel:x:989:
 yoyodine-nativetest:x:1000:

--- a/meta-refkit/conf/distro/include/refkit-supported-recipes.txt
+++ b/meta-refkit/conf/distro/include/refkit-supported-recipes.txt
@@ -161,6 +161,7 @@ libcxxabi@clang-layer
 libdrm@core
 libeigen@openembedded-layer
 liberation-fonts@core
+libevdev@core
 libexif@core
 libffi@core
 libgcc@core
@@ -170,6 +171,7 @@ libgphoto2@openembedded-layer
 libgudev@core
 libical@core
 libidn@core
+libinput@core
 libjpeg-turbo@core
 libmicrohttpd@soletta
 libmpc@core
@@ -196,6 +198,7 @@ libva-intel-driver@intel
 libva@core
 libvorbis@core
 libwebp@core
+libxkbcommon@core
 libxml2@core
 libxslt@core
 linux-firmware@core
@@ -215,6 +218,7 @@ mmap-smack-test@security-smack
 mpfr@core
 mraa-test@iotqa
 mraa@refkit
+mtdev@core
 multipath-tools@openembedded-layer
 ncurses@core
 netbase@core
@@ -303,8 +307,13 @@ valgrind@core
 viennacl@refkit
 vim@openembedded-layer
 volatile-binds@core
+wayland@core
+wayland-protocols@core
+weston@core
+weston-init@core
 wget@core
 wic-tools@core
 wpa-supplicant@core
+xkeyboard-config@core
 xz@core
 zlib@core

--- a/meta-refkit/conf/local.conf.sample
+++ b/meta-refkit/conf/local.conf.sample
@@ -283,6 +283,9 @@ PACKAGE_DEBUG_SPLIT_STYLE = "debug-without-src"
 #
 #require conf/distro/include/refkit-production.inc
 
+# To enable Wayland/Weston with OpenGL support for images, uncomment following line.
+#require conf/distro/include/refkit-core-wayland.inc
+
 # systemd-bootchart is a useful tool to analyze and optimize a system
 # boot time. The tool is available in IoT Reference OS Kit and needs to be activated
 # by a kernel command-line parameter which requires to build a new


### PR DESCRIPTION
Enable support for Wayland graphics through local.conf include. Since
this changes DISTRO_FEATURES checked by multiple recipes, it cannot
be static distro configuration.

Signed-off-by: Jussi Laako <jussi.laako@linux.intel.com>