### PR TITLE
Crontab: Added crontab into refkit_passwd and refkit_group

### DIFF
--- a/meta-refkit/conf/distro/include/refkit-group
+++ b/meta-refkit/conf/distro/include/refkit-group
@@ -2,6 +2,7 @@ adm:x:990:
 appfwtest-commonapp:x:1004:
 audio:x:986:
 cdrom:x:985:
+crontab:x:970:
 dbus:1501
 dbus-x11:1500
 dialout:x:984:

--- a/meta-refkit/conf/distro/include/refkit-passwd
+++ b/meta-refkit/conf/distro/include/refkit-passwd
@@ -1,4 +1,5 @@
 appfwtest-commonapp:x:1004:1004::/home/appfwtest-commonapp:/sbin/nologin
+crontab:x:970:970::/bin/crontab:/sbin/nologin
 evil-bad-groups:x:1003:1003::/home/evil-bad-groups:/sbin/nologin
 foodine-pythontest:x:1002:1002::/home/foodine-pythontest:/sbin/nologin
 iodine-nodetest:x:1001:1001::/home/iodine-nodetest:/sbin/nologin


### PR DESCRIPTION
Required crontab when enable tools-sdk and tools-testapps
in REFKIT_IMAGE_EXTRA_FEATURES
    
Signed-off-by: Choong YinThong <yin.thong.choong@intel.com>