### PR TITLE
meta-iotqa: Clean up and enablement of single-node Bluetooth test cases

### DIFF
--- a/meta-iotqa/conf/test/minnowboardturbot.mask
+++ b/meta-iotqa/conf/test/minnowboardturbot.mask
@@ -1,2 +1,4 @@
 # This file contains tests that can't be run on Minnowboard Turbot
 # /docker/tester-exec.sh will use this file to remove tests from a manifest
+oeqa.runtime.connectivity.bluetooth.bt_command
+oeqa.runtime.connectivity.bluetooth.bt_6lowpan

--- a/meta-iotqa/conf/test/qemu.mask
+++ b/meta-iotqa/conf/test/qemu.mask
@@ -1,6 +1,8 @@
 # This file contains tests that can't be run on QEMU
 # /docker/tester-exec.sh will use this file to remove tests from a manifest
 oeqa.runtime.connectivity.bluetooth.btcheck
+oeqa.runtime.connectivity.bluetooth.bt_command
+oeqa.runtime.connectivity.bluetooth.bt_6lowpan
 oeqa.runtime.connectivity.wifi.wifi_connect
 oeqa.runtime.peripherals.mraa.mraa_gpio
 oeqa.runtime.multimedia.audio.alsa

--- a/meta-iotqa/conf/test/refkit-image-common.manifest
+++ b/meta-iotqa/conf/test/refkit-image-common.manifest
@@ -3,6 +3,8 @@ oeqa.runtime.core.baseos
 oeqa.runtime.connectivity.services.ssh
 oeqa.runtime.connectivity.services.managerdaemon
 oeqa.runtime.connectivity.bluetooth.btcheck
+oeqa.runtime.connectivity.bluetooth.bt_command
+oeqa.runtime.connectivity.bluetooth.bt_6lowpan
 oeqa.runtime.connectivity.wifi.wifi_connect
 oeqa.runtime.programming.python.apprt_python
 oeqa.runtime.multimedia.audio.alsa

--- a/meta-iotqa/lib/oeqa/runtime/connectivity/bluetooth/bluetooth.py
+++ b/meta-iotqa/lib/oeqa/runtime/connectivity/bluetooth/bluetooth.py
@@ -1,13 +1,11 @@
 import time
 import os
-import string
 from oeqa.utils.helper import shell_cmd_timeout
 
+
 class BTFunction(object):
-    """
-    @class BTFunction
-    """
     log = ""
+
     def __init__(self, target):
         self.target = target
         # un-block software rfkill lock
@@ -16,22 +14,14 @@ class BTFunction(object):
         self.target.run('killall hcitool')
 
     def target_collect_info(self, cmd):
-        """
-        @fn target_collect_info
-        @param self
-        @param  cmd
-        @return
-        """
         (status, output) = self.target.run(cmd)
         self.log = self.log + "\n\n[Debug] Command output --- %s: \n" % cmd
         self.log = self.log + output
 
     def target_hciconfig_init(self):
-        ''' init target bluetooth by hciconfig commands
-        @fn target_hciconfig_init
-        @param self
-        @return
-        '''
+        """
+        Init target bluetooth by hciconfig commands
+        """
         (status, output) = self.target.run('hciconfig hci0 reset')
         assert status == 0, "reset hci0 fails, please check if your BT device exists"
         time.sleep(1)
@@ -41,41 +31,33 @@ class BTFunction(object):
         time.sleep(1)
 
     def set_leadv(self):
-        ''' Get hci0 MAC address
-        @fn get_bt_mac
-        @param self
-        @return
-        '''
+        """
+        Get hci0 MAC address
+        """
         (status, output) = self.target.run('hciconfig hci0 leadv')
         time.sleep(2)
         assert status == 0, "Set leadv fail: %s" % (output)
 
     def get_bt_mac(self):
-        ''' Get hci0 MAC address
-        @fn get_bt_mac
-        @param self
-        @return
-        '''
+        """
+        Get hci0 MAC address
+        """
         (status, output) = self.target.run('hciconfig hci0 | grep "BD Address"')
         return output.split()[2]
 
     def get_bt0_ip(self):
-        ''' Get bt0 (ipv6) address
-        @fn get_bt0_ip
-        @param self
-        @return
-        '''
+        """
+        Get bt0 (ipv6) address
+        """
         self.target_collect_info('ifconfig')
         (status, output) = self.target.run('ifconfig bt0 | grep "inet6 addr"')
         assert status == 0, "Get bt0 address failure: %s\n%s" % (output, self.log)
         return output.split('%')[0].split()[2]
 
     def get_name(self):
-        ''' Get bt0 device name by bluetoothctl
-        @fn get_name
-        @param self
-        @return
-        '''
+        """
+        Get bt0 device name by bluetoothctl
+        """
         exp = os.path.join(os.path.dirname(__file__), "files/bt_get_name.exp")
         btmac = self.get_bt_mac()
         cmd = 'expect %s %s %s' % (exp, self.target.ip, btmac)
@@ -91,33 +73,27 @@ class BTFunction(object):
         return ""
 
     def enable_bluetooth(self):
-        ''' enable bluetooth after testing
-        @fn enable_bluetooth
-        @param self
-        @return
-        '''
+        """
+        Enable bluetooth
+        """
         # Enable Bluetooth
         (status, output) = self.target.run('connmanctl enable bluetooth')
         assert status == 0, "Error messages: %s" % output
         time.sleep(1)
 
     def disable_bluetooth(self):
-        ''' disable bluetooth after testing
-        @fn disable_bluetooth
-        @param self
-        @return
-        '''
+        """
+        Disable bluetooth
+        """
         (status, output) = self.target.run('connmanctl disable bluetooth')
         assert status == 0, "Error messages: %s" % output
         # sleep some seconds to ensure disable is done
         time.sleep(1)
 
     def ctl_power_on(self):
-        '''bluetoothctl power on bluetooth device
-        @fn ctl_power_on
-        @param self
-        @return
-        '''
+        """
+        Use bluetoothctl to power on bluetooth device
+        """
         # start bluetoothctl, then input 'power on'
         exp = os.path.join(os.path.dirname(__file__), "files/power_on.exp")
         target_ip = self.target.ip
@@ -127,11 +103,9 @@ class BTFunction(object):
         assert status == 2, "power on command fails: %s" % output
 
     def ctl_power_off(self):
-        '''bluetoothctl power off bluetooth device
-        @fn ctl_power_off
-        @param self
-        @return
-        '''
+        """
+        Use bluetoothctl to power off bluetooth device
+        """
         # start bluetoothctl, then input 'power off'
         exp = os.path.join(os.path.dirname(__file__), "files/power_off.exp")
         target_ip = self.target.ip
@@ -140,12 +114,10 @@ class BTFunction(object):
             output = output.decode("ascii")
         assert status == 2, "power off command fails: %s" % output
 
-    def ctl_visable_on(self):
-        '''bluetoothctl enable visibility
-        @fn ctl_visable_on
-        @param self
-        @return
-        '''
+    def ctl_visible_on(self):
+        """
+        Use bluetoothctl to enable visibility
+        """
         # start bluetoothctl, then input 'discoverable on'
         exp = os.path.join(os.path.dirname(__file__), "files/discoverable_on.exp")
         target_ip = self.target.ip
@@ -154,12 +126,10 @@ class BTFunction(object):
             output = output.decode("ascii")
         assert status == 2, "discoverable on command fails: %s" % output
 
-    def ctl_visable_off(self):
-        '''bluetoothctl disable visibility
-        @fn ctl_visable_off
-        @param self
-        @return
-        '''
+    def ctl_visible_off(self):
+        """
+        Use bluetoothctl to disable visibility
+        """
         # start bluetoothctl, then input 'discoverable off'
         exp = os.path.join(os.path.dirname(__file__), "files/discoverable_off.exp")
         target_ip = self.target.ip
@@ -169,11 +139,9 @@ class BTFunction(object):
         assert status == 2, "discoverable off command fails: %s" % output
 
     def insert_6lowpan_module(self):
-        '''Insert BLE 6lowpan module
-        @fn insert_6lowpan_module
-        @param self
-        @return
-        '''
+        """
+        Insert BLE 6lowpan module
+        """
         status, output = self.target.run('modprobe bluetooth_6lowpan')
         assert status == 0, "insert ble 6lowpan module fail: %s" % output
         # check lsmod, to see if the module is in
@@ -185,11 +153,9 @@ class BTFunction(object):
             assert False, "BLE 6lowpan module insert fails. %s" % self.log
 
     def enable_6lowpan_ble(self):
-        '''Enable 6lowpan over BLE
-        @fn enable_6lowpan_ble
-        @param self
-        @return
-        '''
+        """
+        Enable 6lowpan over BLE
+        """
         self.insert_6lowpan_module()
         status, output = self.target.run('echo 1 > /sys/kernel/debug/bluetooth/6lowpan_enable')
         assert status == 0, "Enable ble 6lowpan fail: %s" % output
@@ -202,11 +168,9 @@ class BTFunction(object):
             assert False, "BLE 6lowpan interface is: %s\n%s" % (output, self.log)
 
     def disable_6lowpan_ble(self):
-        '''Disable 6lowpan over BLE
-        @fn disable_6lowpan_ble
-        @param self
-        @return
-        '''
+        """
+        Disable 6lowpan over BLE
+        """
         status, output = self.target.run('echo 0 > /sys/kernel/debug/bluetooth/6lowpan_enable')
         assert status == 0, "Disable ble 6lowpan fail: %s" % output
         # check file number, it should be 1
@@ -218,23 +182,19 @@ class BTFunction(object):
             pass
 
     def bt0_ping6_check(self, ipv6):
-        ''' On main target, run ping6 to ping second's ipv6 address
-        @fn bt0_ping6_check
-        @param self
+        """ On main target, run ping6 to ping second's ipv6 address
+
         @param ipv6: second target ipv6 address
-        @return
-        '''
-        cmd='ping6 -I bt0 -c 5 %s' % ipv6
+        """
+        cmd = 'ping6 -I bt0 -c 5 %s' % ipv6
         (status, output) = self.target.run(cmd)
         assert status == 0, "Ping second target lowpan0 ipv6 address fail: %s" % output
 
     def bt0_ssh_check(self, ipv6):
-        ''' On main target, ssh to second
-        @fn bt0_ssh_check
-        @param self
+        """ On main target, ssh to second
+
         @param ipv6: second target ipv6 address
-        @return
-        '''
+        """
         # ssh root@<ipv6 address>%bt0
         ssh_key = os.path.join(os.path.dirname(__file__), "files/refkit_qa_rsa")
         self.target.copy_to(ssh_key, "/tmp/")
@@ -248,12 +208,10 @@ class BTFunction(object):
         assert status == 2, "Error messages: %s" % output
 
     def connect_6lowpan_ble(self, second):
-        '''Build 6lowpan connection between taregts[0] and targets[1] over BLE
-        @fn connect_6lowpan_ble
-        @param self
+        """ Build 6lowpan connection between targets[0] and targets[1] over BLE
+
         @param second: second target
-        @return
-        '''
+        """
         self.enable_6lowpan_ble()
         second.enable_6lowpan_ble()
         success = 1
@@ -277,13 +235,11 @@ class BTFunction(object):
         assert success == 0, "No bt0 generated: %s\n%s" % (output, self.log)
 
     def gatt_basic_check(self, btmac, point):
-        '''Do basic gatt tool check points.
-        @fn gatt_basic_check
-        @param self
+        """ Do basic gatt tool check points.
+
         @param btmac: remote advertising device BT MAC address
         @param point: a string for basic checking points.
-        @return
-        '''
+        """
         # Local does gatttool commands
         if point == "connect":
             exp = os.path.join(os.path.dirname(__file__), "files/gatt_connect.exp")

--- a/meta-iotqa/lib/oeqa/runtime/connectivity/bluetooth/bt_6lowpan.py
+++ b/meta-iotqa/lib/oeqa/runtime/connectivity/bluetooth/bt_6lowpan.py
@@ -6,7 +6,11 @@ from oeqa.utils.helper import shell_cmd_timeout
 class CommBT6LowPAN(oeRuntimeTest):
     def setUp(self):
         self.bt = bluetooth.BTFunction(self.target)
+        self.bt.enable_bluetooth()
         self.bt.target_hciconfig_init()
+
+    def tearDown(self):
+        self.bt.disable_bluetooth()
 
     def test_bt_insert_6lowpan_module(self):
         """

--- a/meta-iotqa/lib/oeqa/runtime/connectivity/bluetooth/bt_6lowpan.py
+++ b/meta-iotqa/lib/oeqa/runtime/connectivity/bluetooth/bt_6lowpan.py
@@ -1,36 +1,23 @@
-import os
-import time
-from oeqa.runtime.bluetooth import bluetooth
+from oeqa.runtime.connectivity.bluetooth import bluetooth
 from oeqa.oetest import oeRuntimeTest
 from oeqa.utils.helper import shell_cmd_timeout
 
+
 class CommBT6LowPAN(oeRuntimeTest):
-    """
-    @class CommBT6LowPAN
-    """
     def setUp(self):
-        """
-        @fn setUp
-        @param self
-        @return
-        """
         self.bt = bluetooth.BTFunction(self.target)
         self.bt.target_hciconfig_init()
 
     def test_bt_insert_6lowpan_module(self):
-        '''Insert 6lowpan module
-        @fn test_bt_insert_6lowpan_module
-        @param self
-        @return
-        '''
+        """
+        Insert 6lowpan module
+        """
         self.bt.insert_6lowpan_module()
 
     def test_bt_enable_6lowpan_ble(self):
-        '''Enable 6lowpan over BLE
-        @fn test_bt_enable_6lowpan_ble
-        @param self
-        @return
-        '''
+        """
+        Enable 6lowpan over BLE
+        """
         self.bt.enable_6lowpan_ble()
 
 ##

--- a/meta-iotqa/lib/oeqa/runtime/connectivity/bluetooth/bt_6lowpan_mnode.py
+++ b/meta-iotqa/lib/oeqa/runtime/connectivity/bluetooth/bt_6lowpan_mnode.py
@@ -1,19 +1,10 @@
-import os
-import time
-from oeqa.runtime.bluetooth import bluetooth
+from oeqa.runtime.connectivity.bluetooth import bluetooth
 from oeqa.oetest import oeRuntimeTest
 from oeqa.utils.helper import shell_cmd_timeout
 
+
 class CommBT6LowPanMNode(oeRuntimeTest):
-    """
-    @class CommBT6LowPanMNode
-    """
     def setUp(self):
-        """
-        @fn setUp
-        @param self
-        @return
-        """
         self.bt1 = bluetooth.BTFunction(self.targets[0])
         self.bt2 = bluetooth.BTFunction(self.targets[1])
 
@@ -21,58 +12,43 @@ class CommBT6LowPanMNode(oeRuntimeTest):
         self.bt2.target_hciconfig_init()
 
     def tearDown(self):
-        """
-        @fn tearDown
-        @param self
-        @return
-        """
         self.bt1.disable_6lowpan_ble()
         self.bt2.disable_6lowpan_ble()
 
     def test_bt_connect_6lowpan(self):
-        '''Setup two devices with BLE
-        @fn test_bt_connect_6lowpan
-        @param self
-        @return
-        '''
+        """
+        Setup two devices with BLE
+        """
         self.bt1.connect_6lowpan_ble(self.bt2)
 
     def test_bt_6lowpan_ping6_out(self):
-        '''Setup two devices with BLE, and ping each other
-        @fn test_bt_6lowpan_ping6_out
-        @param self
-        @return
-        '''
+        """
+        Setup two devices with BLE, and ping each other
+        """
         self.bt1.connect_6lowpan_ble(self.bt2)
         # first device to ping second device
         self.bt1.bt0_ping6_check(self.bt2.get_bt0_ip())
 
     def test_bt_6lowpan_be_pinged(self):
-        '''Setup two devices with BLE, and ping each other
-        @fn test_bt_6lowpan_be_pinged
-        @param self
-        @return
-        '''
+        """
+        Setup two devices with BLE, and ping each other
+        """
         self.bt1.connect_6lowpan_ble(self.bt2)
         # first device to ping second device
         self.bt2.bt0_ping6_check(self.bt1.get_bt0_ip())
 
     def test_bt_6lowpan_ssh_to(self):
-        '''Setup two devices with BLE, and ssh to remote
-        @fn test_bt_6lowpan_ssh_to
-        @param self
-        @return
-        '''
+        """
+        Setup two devices with BLE, and ssh to remote
+        """
         self.bt1.connect_6lowpan_ble(self.bt2)
         # first device to ping second device
         self.bt1.bt0_ssh_check(self.bt2.get_bt0_ip())
 
     def test_bt_6lowpan_be_ssh(self):
-        '''Setup two devices with BLE, and remote ssh to self
-        @fn test_bt_6lowpan_be_ssh
-        @param self
-        @return
-        '''
+        """
+        Setup two devices with BLE, and remote ssh to self
+        """
         self.bt1.connect_6lowpan_ble(self.bt2)
         # first device to ping second device
         self.bt2.bt0_ssh_check(self.bt1.get_bt0_ip())

--- a/meta-iotqa/lib/oeqa/runtime/connectivity/bluetooth/bt_command.py
+++ b/meta-iotqa/lib/oeqa/runtime/connectivity/bluetooth/bt_command.py
@@ -10,7 +10,11 @@ from oeqa.utils.helper import get_files_dir
 class CommBTTest(oeRuntimeTest):
     def setUp(self):
         self.bt = bluetooth.BTFunction(self.target)
+        self.bt.enable_bluetooth()
         self.bt.target_hciconfig_init()
+
+    def tearDown(self):
+        self.bt.disable_bluetooth()
 
     def test_bt_power_on(self):
         """

--- a/meta-iotqa/lib/oeqa/runtime/connectivity/bluetooth/bt_command.py
+++ b/meta-iotqa/lib/oeqa/runtime/connectivity/bluetooth/bt_command.py
@@ -1,67 +1,50 @@
 import os
 import time
 import subprocess
-from oeqa.runtime.bluetooth import bluetooth
+from oeqa.runtime.connectivity.bluetooth import bluetooth
 from oeqa.oetest import oeRuntimeTest
 from oeqa.utils.helper import shell_cmd_timeout
 from oeqa.utils.helper import get_files_dir
 
+
 class CommBTTest(oeRuntimeTest):
-    """
-    @class CommBTTest
-    """
     def setUp(self):
-        """
-        @fn setUp
-        @param self
-        @return
-        """
         self.bt = bluetooth.BTFunction(self.target)
         self.bt.target_hciconfig_init()
 
     def test_bt_power_on(self):
-        '''enable bluetooth device
-        @fn test_bt_power_on
-        @param self
-        @return
-        '''
+        """
+        Enable bluetooth device
+        """
         self.target.run('hciconfig hci0 down')
         self.bt.ctl_power_on()
 
     def test_bt_power_off(self):
-        '''disable bluetooth device
-        @fn test_bt_power_off
-        @param self
-        @return
-        '''
+        """
+        Disable bluetooth device
+        """
         self.target.run('hciconfig hci0 up')
         self.bt.ctl_power_off()
 
-    def test_bt_visable_on(self):
-        '''enable visibility
-        @fn test_bt_visable_on
-        @param self
-        @return
-        '''
+    def test_bt_visible_on(self):
+        """
+        Enable visibility
+        """
         self.target.run('hciconfig hci0 noscan')
-        self.bt.ctl_visable_on()
+        self.bt.ctl_visible_on()
 
-    def test_bt_visable_off(self):
-        '''disable visibility
-        @fn test_bt_visable_off
-        @param self
-        @return
-        '''
+    def test_bt_visible_off(self):
+        """
+        Disable visibility
+        """
         self.target.run('hciconfig hci0 piscan')
-        self.bt.ctl_visable_off()
+        self.bt.ctl_visible_off()
 
     def test_bt_change_name(self):
-        '''change BT device name
-        @fn test_bt_change_name
-        @param self
-        @return
-        '''
-        new_name="iot-bt-test"
+        """
+        Change BT device name
+        """
+        new_name = "iot-bt-test"
         self.target.run('hciconfig hci0 name %s' % new_name)
         name = self.bt.get_name()
         if type(name) is bytes:
@@ -69,7 +52,7 @@ class CommBTTest(oeRuntimeTest):
         if name == new_name:
             pass
         else:
-           self.assertEqual(1, 0, msg="Bluetooth set name fails. Current name is: %s" % name)
+            self.assertEqual(1, 0, msg="Bluetooth set name fails. Current name is: %s" % name)
 
 ##
 # @}

--- a/meta-iotqa/lib/oeqa/runtime/connectivity/bluetooth/bt_command_mnode.py
+++ b/meta-iotqa/lib/oeqa/runtime/connectivity/bluetooth/bt_command_mnode.py
@@ -1,46 +1,35 @@
 import os
 import time
 import subprocess
-from oeqa.runtime.bluetooth import bluetooth
+from oeqa.runtime.connectivity.bluetooth import bluetooth
 from oeqa.oetest import oeRuntimeTest
 from oeqa.utils.helper import shell_cmd_timeout
 from oeqa.utils.helper import get_files_dir
 
+
 class CommBTTestMNode(oeRuntimeTest):
-    """
-    @class CommBTTestMNode
-    """
     @classmethod
     def setUpClass(cls):
-        '''Copy gatttool to /tmp/ folder
-        @fn setUpClass
-        @param cls
-        @return
-        '''
-        bt1=bluetooth.BTFunction(cls.tc.targets[0])
-        bt2=bluetooth.BTFunction(cls.tc.targets[1])
+        """
+        Copy gatttool to /tmp/ folder
+        """
+        bt1 = bluetooth.BTFunction(cls.tc.targets[0])
+        bt2 = bluetooth.BTFunction(cls.tc.targets[1])
         copy_to_path = os.path.join(get_files_dir(), 'gatttool')
         cls.tc.targets[0].copy_to(copy_to_path, "/tmp/")
         bt1.target.run('chmod +x /tmp/gatttool')
         bt2.target.run('chmod +x /tmp/gatttool')
 
     def setUp(self):
-        """
-        @fn setUp
-        @param self
-        @return
-        """
         self.bt1 = bluetooth.BTFunction(self.targets[0])
         self.bt2 = bluetooth.BTFunction(self.targets[1])
         self.bt1.target_hciconfig_init()
         self.bt2.target_hciconfig_init()
 
     def test_bt_gatt_read_primary(self):
-        '''Use gatttool to show remote primary attr handles
-        @fn test_bt_gatt_read_primary
-        @param self
-        @return
-        '''
+        """
+        Use gatttool to show remote primary attr handles
+        """
         for i in range(3):
             self.bt2.target_hciconfig_init()
             self.bt2.set_leadv()
@@ -51,11 +40,9 @@ class CommBTTestMNode(oeRuntimeTest):
         self.assertEqual(status, 0, msg="gatttool Primary is wrong: %s" % output)
 
     def test_bt_gatt_read_characteristics(self):
-        '''Use gatttool to show target characteristics handles
-        @fn test_bt_gatt_read_characteristics
-        @param self
-        @return
-        '''
+        """
+        Use gatttool to show target characteristics handles
+        """
         for i in range(3):
             self.bt2.target_hciconfig_init()
             self.bt2.set_leadv()
@@ -66,11 +53,9 @@ class CommBTTestMNode(oeRuntimeTest):
         self.assertEqual(status, 0, msg="gatttool characteristics fails: %s" % output)
 
     def test_bt_gatt_read_handle(self):
-        '''Use gatttool to read target handle value
-        @fn test_bt_gatt_read_handle
-        @param self
-        @return
-        '''
+        """
+        Use gatttool to read target handle value
+        """
         for i in range(3):
             self.bt2.target_hciconfig_init()
             self.bt2.set_leadv()
@@ -81,11 +66,9 @@ class CommBTTestMNode(oeRuntimeTest):
         self.assertEqual(status, 0, msg="gatttool read handle fails: %s" % output)
 
     def test_bt_gatt_connect(self):
-        '''Use gatttool interactive mode to do connect
-        @fn test_bt_gatt_connect
-        @param self
-        @return
-        '''
+        """
+        Use gatttool interactive mode to do connect
+        """
         for i in range(3):
             self.bt2.target_hciconfig_init()
             self.bt2.set_leadv()
@@ -96,11 +79,9 @@ class CommBTTestMNode(oeRuntimeTest):
         self.assertEqual(status, 2, msg="gatttool connect fails: %s" % output)
 
     def test_bt_remote_gatt_read_primary(self):
-        '''Use gatttool to show host primary attr handles
-        @fn test_bt_remote_gatt_read_primary
-        @param self
-        @return
-        '''
+        """
+        Use gatttool to show host primary attr handles
+        """
         for i in range(3):
             self.bt1.target_hciconfig_init()
             self.bt1.set_leadv()
@@ -111,11 +92,9 @@ class CommBTTestMNode(oeRuntimeTest):
         self.assertEqual(status, 0, msg="gatttool be read primary fails: %s" % output)
 
     def test_bt_remote_gatt_read_characteristics(self):
-        '''Use gatttool to show host characteristics handles
-        @fn test_bt_remote_gatt_read_characteristics
-        @param self
-        @return
-        '''
+        """
+        Use gatttool to show host characteristics handles
+        """
         for i in range(3):
             self.bt1.target_hciconfig_init()
             self.bt1.set_leadv()
@@ -126,11 +105,9 @@ class CommBTTestMNode(oeRuntimeTest):
         self.assertEqual(status, 0, msg="gatttool be read characteristics fails: %s" % output)
 
     def test_bt_remote_gatt_read_handle(self):
-        '''Use gatttool to read host handle value
-        @fn test_bt_remote_gatt_read_handle
-        @param self
-        @return
-        '''
+        """
+        Use gatttool to read host handle value
+        """
         for i in range(3):
             self.bt1.target_hciconfig_init()
             self.bt1.set_leadv()
@@ -141,11 +118,9 @@ class CommBTTestMNode(oeRuntimeTest):
         self.assertEqual(status, 0, msg="gatttool be read handle fails: %s" % output)
 
     def test_bt_remote_gatt_connect(self):
-        '''Use gatttool interactive mode to do connect to host
-        @fn test_bt_remote_gatt_connect
-        @param self
-        @return
-        '''
+        """
+        Use gatttool interactive mode to do connect to host
+        """
         for i in range(3):
             self.bt1.target_hciconfig_init()
             self.bt1.set_leadv()
@@ -156,11 +131,9 @@ class CommBTTestMNode(oeRuntimeTest):
         self.assertEqual(status, 2, msg="gatttool be connected fails: %s" % output)
 
     def test_bt_visible(self):
-        '''Do traditional visible and be scanned by other (not ble scan)
-        @fn test_bt_visible
-        @param self
-        @return
-        '''
+        """
+        Do traditional visible and be scanned by other (not ble scan)
+        """
         self.bt1.target.run('hciconfig hci0 noleadv')
         for i in range(3):
             # For init function already set visible status, directly be scanned.
@@ -174,11 +147,9 @@ class CommBTTestMNode(oeRuntimeTest):
         self.assertEqual(status, 2, msg="Scan remote device fails: %s" % output)
 
     def test_bt_scan(self):
-        '''Scan nearby bluetooth devices (not ble scan)
-        @fn test_bt_scan
-        @param self
-        @return
-        '''
+        """
+        Scan nearby bluetooth devices (not ble scan)
+        """
         self.bt2.target.run('hciconfig hci0 noleadv')
         for i in range(3):
             # For init function already set visible status, directly be scanned.
@@ -192,11 +163,9 @@ class CommBTTestMNode(oeRuntimeTest):
         self.assertEqual(status, 2, msg="Scan remote device fails: %s" % output)
 
     def test_bt_le_advertising(self):
-        '''Target does LE advertising, another device scans it
-        @fn test_bt_le_advertising
-        @param self
-        @return
-        '''
+        """
+        Target does LE advertising, another device scans it
+        """
         for i in range(3):
             # close legacy iscan mode
             self.bt1.target.run('hciconfig hci0 noscan')
@@ -217,11 +186,9 @@ class CommBTTestMNode(oeRuntimeTest):
         self.assertEqual(status, 2, msg="Be LE-scanned fails: %s" % output)
 
     def test_bt_le_scan(self):
-        '''Another device (host) does LE advertising, target scans it
-        @fn test_bt_le_scan
-        @param self
-        @return
-        '''
+        """
+        Another device (host) does LE advertising, target scans it
+        """
         for i in range(3):
             # close legacy iscan mode
             self.bt2.target.run('hciconfig hci0 noscan')
@@ -242,11 +209,9 @@ class CommBTTestMNode(oeRuntimeTest):
         self.assertEqual(status, 2, msg="LE Scan other fails: %s" % output)
 
     def test_bt_pairing(self):
-        '''Use bluetoothctl to pair IoT device with host
-        @fn test_bt_pairing
-        @param self
-        @return
-        '''
+        """
+        Use bluetoothctl to pair IoT device with host
+        """
         # On remote, start pair_slave in back-ground
         slave_exp = os.path.join(os.path.dirname(__file__), "files/bt_pair_slave_on_iot.exp")
         cmd = "%s %s %s" % (slave_exp, self.bt2.target.ip, self.bt1.get_bt_mac())

--- a/meta-iotqa/lib/oeqa/runtime/connectivity/bluetooth/bt_stability.py
+++ b/meta-iotqa/lib/oeqa/runtime/connectivity/bluetooth/bt_stability.py
@@ -11,10 +11,12 @@ class BTStabilityTest(oeRuntimeTest):
     power_cycles = 200
 
     def setUp(self):
-        """
-        Initialize bluetooth class
-        """
         self.bt = bluetooth.BTFunction(self.target)
+        self.bt.target_hciconfig_init()
+        self.bt.enable_bluetooth()
+
+    def tearDown(self):
+        self.bt.disable_bluetooth()
 
     def test_bt_onoff_multiple_times(self):
         """

--- a/meta-iotqa/lib/oeqa/runtime/connectivity/bluetooth/bt_stability.py
+++ b/meta-iotqa/lib/oeqa/runtime/connectivity/bluetooth/bt_stability.py
@@ -1,49 +1,41 @@
 import os
 import time
 import subprocess
-from oeqa.runtime.bluetooth import bluetooth
+from oeqa.runtime.connectivity.bluetooth import bluetooth
 from oeqa.oetest import oeRuntimeTest
 from oeqa.utils.helper import shell_cmd_timeout
 from oeqa.utils.helper import get_files_dir
 
+
 class BTStabilityTest(oeRuntimeTest):
-    """
-    @class BTStabilityTest
-    """
+    power_cycles = 200
+
     def setUp(self):
-        ''' initialize bluetooth class
-        @fn setUp
-        @param self
-        @return
-        '''
+        """
+        Initialize bluetooth class
+        """
         self.bt = bluetooth.BTFunction(self.target)
 
-    def test_bt_onoff_multiple_time(self):
-        '''bluetoothctl to power on/off for multiple times
-        @fn test_bt_onoff_multiple_time
-        @param self
-        @return
-        '''
-        time=200
-        for i in range(1, time):
+    def test_bt_onoff_multiple_times(self):
+        """
+        Use bluetoothctl to power on/off multiple times
+        """
+        for i in range(1, self.power_cycles):
             self.bt.ctl_power_on()
             self.bt.ctl_power_off()
             if i % 20 == 0:
-                print ("Finish %d times, successful." % i)
+                print ("Finished %d cycles successfuly." % i)
 
-    def test_bt_visable_onoff_multiple_time(self):
-        '''bluetoothctl to turn discoverable on/off for multiple times
-        @fn test_bt_visable_onoff_multiple_time
-        @param self
-        @return
-        '''
+    def test_bt_visible_onoff_multiple_times(self):
+        """
+        Use bluetoothctl to turn discoverable on/off multiple times
+        """
         self.bt.ctl_power_on()
-        time=200
-        for i in range(1, time):
-            self.bt.ctl_visable_on()
-            self.bt.ctl_visable_off()
+        for i in range(1, self.power_cycles):
+            self.bt.ctl_visible_on()
+            self.bt.ctl_visible_off()
             if i % 20 == 0:
-                print ("Finish %d times, successful." % i)
+                print ("Finished %d cycles successfuly." % i)
 
 ##
 # @}

--- a/meta-refkit-core/classes/refkit-image.bbclass
+++ b/meta-refkit-core/classes/refkit-image.bbclass
@@ -139,6 +139,12 @@ inherit refkit-hash-dm-verity-key
 # used only in "development" configuration.
 FEATURE_PACKAGES_common-test = "packagegroup-common-test"
 
+# bluetoothctl is used on "development" configuration to execute some of
+# the test cases for Bluetooth. It is enabled here because adding
+# it to packagegroup-common-test has no effect due to a bug
+# on BAD_RECOMMENDS functionality (YOCTO #11427)
+BAD_RECOMMENDATIONS_remove = "${@ 'bluez5-client' if (d.getVar('IMAGE_MODE') or 'production') != 'production' else '' }"
+
 # Additional features and packages used by all profile images
 # and the refkit-image-common.bb. Not essential for booting
 # and thus not included in refkit-image-minimal.bb. Product


### PR DESCRIPTION
This PR cleans up and includes single-node Bluetooth test cases in the refkit-image-common manifest (this is tracked on Yocto bug #11255). It also adds bluetoothctl back to development images as some of the enabled test cases make use of this tool.

This PR replaces https://github.com/intel/intel-iot-refkit/pull/116