### PR TITLE
Add input group because systemd is anyway creating it.

### DIFF
--- a/meta-refkit/recipes-core/base-passwd/files/group.master
+++ b/meta-refkit/recipes-core/base-passwd/files/group.master
@@ -1,5 +1,6 @@
 root:*:0:
 audio:*:29:
 rfkill:*:50:
+input:*:55:
 nobody:*:65533:
 nogroup:*:65534:


### PR DESCRIPTION
Signed-off-by: Jaska Uimonen <jaska.uimonen@intel.com>