### PR TITLE
beignet-550x: add new recipe.

### DIFF
--- a/meta-refkit/conf/distro/include/refkit-supported-recipes.txt
+++ b/meta-refkit/conf/distro/include/refkit-supported-recipes.txt
@@ -45,6 +45,7 @@ base-passwd@core
 bash-completion@core
 bash@core
 bc@core
+beignet-550x@refkit
 beignet-570x@refkit
 beignet-minnowmax@refkit
 binutils@core

--- a/meta-refkit/recipes-opencl/beignet/beignet-550x_git.bb
+++ b/meta-refkit/recipes-opencl/beignet/beignet-550x_git.bb
@@ -1,0 +1,5 @@
+# Recipe for compiling beignet for Intel 550x
+
+require beignet.inc
+
+EXTRA_OECMAKE_append = " -DGEN_PCI_ID=0x1A85"

--- a/meta-refkit/recipes-opencl/beignet/beignet-570x_git.bb
+++ b/meta-refkit/recipes-opencl/beignet/beignet-570x_git.bb
@@ -1,4 +1,4 @@
-# Recipe for compiling beignet for Intel Joule 570x
+# Recipe for compiling beignet for Intel 570x
 
 require beignet.inc
 

--- a/meta-refkit/recipes-opencl/packagegroups/packagegroup-opencl.bb
+++ b/meta-refkit/recipes-opencl/packagegroups/packagegroup-opencl.bb
@@ -6,5 +6,6 @@ inherit packagegroup
 RDEPENDS_${PN} = " \
     beignet-minnowmax \
     beignet-570x \
+    beignet-550x \
     ocl-icd \
 "


### PR DESCRIPTION
550x board GPU has a different PCI ID than 570x. Add a new beignet recipe to support it.