### PR TITLE
meta-iotqa: Use fixed dir name inside testsuite tarball and improve readme

### DIFF
--- a/meta-iotqa/README.md
+++ b/meta-iotqa/README.md
@@ -12,13 +12,17 @@ and after running `$ docker/local-build.sh` you should have the test files built
 
 Follow the guide on
 [building without docker](https://github.com/intel/intel-iot-refkit#building-without-docker)
-and before building an image add `INHERIT += "test-iot"` to `local.conf`:
-```
-echo 'INHERIT += "test-iot"' >> conf/local.conf
-```
+and before building an image add `INHERIT += "test-iot"` to `conf/local.conf`.
+
 Then build the image with `do_test_iot_export` task eg.:
 ```
 $ bitbake refkit-image-common -c do_test_iot_export
+```
+
+If the task fails, you may need to use `cleanall` task for the image and then
+try again:
+```
+$ bitbake -c cleanall refkit-image-common
 ```
 
 ## Setting up environment for running tests
@@ -37,7 +41,7 @@ After building the tests you can find the test files from
 Extracting the the test files can be done with:
 ```
 $ tar xf iot-testsuite.tar.gz
-$ tar xf iot-testfiles.xxx.tar.gz -C iottest/
+$ tar xf iot-testfiles.intel-corei7.tar.gz -C iottest/
 ```
 
 Running the tests:

--- a/meta-iotqa/README.md
+++ b/meta-iotqa/README.md
@@ -4,22 +4,27 @@ This layer is originally from https://github.com/ostroproject/meta-iotqa
 
 ## Building tests with docker
 
-Follow the guide on [building with docker](https://github.com/intel/intel-iot-refkit#building-with-docker) and after running `$ docker/local-build.sh` you should have the test files built.
+Follow the guide on
+[building with docker](https://github.com/intel/intel-iot-refkit#building-with-docker)
+and after running `$ docker/local-build.sh` you should have the test files built.
 
 ## Building tests without docker
 
-Follow the guide on [building without docker](https://github.com/intel/intel-iot-refkit#building-without-docker) and before building an image add 'INHERIT += "test-iot"' to local.conf:
+Follow the guide on
+[building without docker](https://github.com/intel/intel-iot-refkit#building-without-docker)
+and before building an image add `INHERIT += "test-iot"` to `local.conf`:
 ```
 echo 'INHERIT += "test-iot"' >> conf/local.conf
 ```
-Then build the image with 'do_test_iot_export' task eg.:
+Then build the image with `do_test_iot_export` task eg.:
 ```
-bitbake refkit-image-common:do_test_iot_export
+$ bitbake refkit-image-common -c do_test_iot_export
 ```
 
 ## Setting up environment for running tests
 
-1. Host: Ubuntu 14.04 is tested and recommended. Install expect as some tests might require it: `$ sudo apt-get install expect`
+1. Host: Ubuntu 14.04 is tested and recommended. Install expect as some tests
+might require it: `$ sudo apt-get install expect`
 
 2. Boot and install the image to target device
 
@@ -27,17 +32,18 @@ bitbake refkit-image-common:do_test_iot_export
 
 ## Running tests
 
-After building the tests you can find the test files from intel-iot-refkit/build/tmp-glibc/deploy/testsuite/refkit-image-<profile>/.
+After building the tests you can find the test files from
+`intel-iot-refkit/build/tmp-glibc/deploy/testsuite/refkit-image-<profile>/`.
 Extracting the the test files can be done with:
 ```
-$ tar xvf iot-testsuite.tar.gz`
-$ tar xvf iot-testfiles.xxx.tar.gz -C iottest/
+$ tar xf iot-testsuite.tar.gz
+$ tar xf iot-testfiles.xxx.tar.gz -C iottest/
 ```
 
 Running the tests:
 ```
 $ cd iottest
-$ python runtest.py -f testplan/xxx.manifest -m <target machine> -t <target IP>[:<port number>] -s <host IP>
+$ python runtest.py -f testplan/<manifest> -m <target machine> -t <target IP>[:<port number>] -s <host IP>
 ```
 
 For example:

--- a/meta-iotqa/classes/test-iot.bbclass
+++ b/meta-iotqa/classes/test-iot.bbclass
@@ -239,16 +239,17 @@ def re_creat_dir(path):
 
 
 #package test suite as tarball
-def pack_tarball(d, tdir, fname):
+def pack_tarball(d, tdir, fname, arcname):
     import tarfile
     tar = tarfile.open(fname, "w:gz")
-    tar.add(tdir, arcname=os.path.basename(tdir))
+    tar.add(tdir, arcname=arcname)
     tar.close()
 
 #bitbake task - export iot test suite
 python do_test_iot_export() {
     import shutil
     deploydir = "deploy"
+    testsuitedir = "iottest"
     exportdir = d.getVar("TEST_EXPORT_DIR", True)
     if not exportdir:
         exportdir = "iottest"
@@ -263,7 +264,7 @@ python do_test_iot_export() {
     outdir = d.getVar("DEPLOY_DIR_TESTSUITE", True)
     bb.utils.mkdirhier(outdir)
     fname = os.path.join(outdir, "iot-testsuite.tar.gz")
-    pack_tarball(d, exportdir, fname)
+    pack_tarball(d, exportdir, fname, testsuitedir)
     bb.plain("export test suite to ", fname)
     re_creat_dir(deploydir)
     shutil.copytree(os.path.join(d.getVar("DEPLOY_DIR", True), "files"), os.path.join(deploydir,"files"))
@@ -272,7 +273,7 @@ python do_test_iot_export() {
     bb.utils.mkdirhier(filesdir)
     dump_builddata(d, filesdir)
     fname = os.path.join(outdir, "iot-testfiles.%s.tar.gz" % machine)
-    pack_tarball(d, deploydir, fname)
+    pack_tarball(d, deploydir, fname, deploydir)
     bb.plain("export test files to ", fname)
 }
 


### PR DESCRIPTION
Depending on if `do_test_iot_export` task is done with or without docker the directory name inside created testsuite tarball will differ. So just use specific name with it ("iottest"). Also improve meta-iotqa/README.MD. 