### PR TITLE
meta-iotqa: modify allowed errors whitelist

### DIFF
--- a/meta-iotqa/lib/oeqa/runtime/core/baseos/baseos.py
+++ b/meta-iotqa/lib/oeqa/runtime/core/baseos/baseos.py
@@ -107,9 +107,7 @@ class BaseOsTest(oeRuntimeTest):
             "hci_intel: probe of INT33E1:00 failed with error -2",
             "Error changing net interface name 'usb0' to",
             "*ERROR* dp aux hw did not signal timeout",
-            "*ERROR* dp_aux_ch not done status 0xa1450064",
-            # Bug 11105, in Refkit bugzilla
-            "file /var/lib/alsa/asound.state lock error"
+            "*ERROR* dp_aux_ch not done status 0xa1450064"
             ]
         self.longMessage = True
         cmd = "journalctl -ab"

--- a/meta-iotqa/lib/oeqa/runtime/core/baseos/baseos.py
+++ b/meta-iotqa/lib/oeqa/runtime/core/baseos/baseos.py
@@ -107,6 +107,7 @@ class BaseOsTest(oeRuntimeTest):
             "hci_intel: probe of INT33E1:00 failed with error -2",
             "Error changing net interface name 'usb0' to",
             "*ERROR* dp aux hw did not signal timeout",
+            "*ERROR* dp_aux_ch not done status 0xa1450064",
             # Bug 11105, in Refkit bugzilla
             "file /var/lib/alsa/asound.state lock error"
             ]


### PR DESCRIPTION
Message "*ERROR* dp_aux_ch not done status 0xa1450064"
is randomly present in few percent of test runs.

Remove alsa error msg not spotted in last CI PR 500 runs

Signed-off-by: Olev Kartau <olev.kartau@intel.com>