### PR TITLE
Clean up beignet recipe

### DIFF
--- a/meta-refkit-computervision/recipes-opencl/beignet/beignet.inc
+++ b/meta-refkit-computervision/recipes-opencl/beignet/beignet.inc
@@ -24,12 +24,7 @@ DEPENDS_class-native = "clang-native"
 
 CL_HW_TARGET ?= "${@d.getVar('PN').split('-')[1]}"
 
-inherit cmake pkgconfig
-
-# There is no python in sysroot -> look for it on the build host.
-# WARNING: remove CLang from the host otherwise it might get into use
-#          instead of the one from meta-clang.
-OECMAKE_FIND_ROOT_PATH_MODE_PROGRAM = "BOTH"
+inherit cmake pkgconfig pythonnative
 
 EXTRA_OECMAKE = " -DSTANDALONE_GBE_COMPILER_DIR=${STAGING_BINDIR_NATIVE} -DLLVM_LIBRARY_DIR=${STAGING_LIBDIR} -DBEIGNET_INSTALL_DIR=${libdir}/beignet-${CL_HW_TARGET}"
 EXTRA_OECMAKE_class-native = " -DBEIGNET_INSTALL_DIR=/usr/lib/beignet -DLLVM_LIBRARY_DIR=${STAGING_LIBDIR_NATIVE}"

--- a/meta-refkit-computervision/recipes-opencl/beignet/beignet.inc
+++ b/meta-refkit-computervision/recipes-opencl/beignet/beignet.inc
@@ -12,7 +12,7 @@ BBCLASSEXTEND = "native"
 
 # CMake cannot digest "+" in pathes -> replace it with dots.
 PV = "1.3.1.${@ 'git${SRCPV}'.replace('+', '.')}"
-SRCREV = "beaf26ff429bd8660d2103fb682243efeb828ab1"
+SRCREV = "6804cca263edd11fd03b2d7f5b7ba034d9a013c3"
 S = "${WORKDIR}/git"
 
 # we need to depend on ocl-icd, so that the exported symbols go right
@@ -23,11 +23,6 @@ DEPENDS_class-native = "clang-native"
 # installing the library.
 
 CL_HW_TARGET ?= "${@d.getVar('PN').split('-')[1]}"
-
-# built-in kernels depend on libocl's headers (e.g. ocl_as.h) yet there is no
-# dependency specified for that in beignet's build system. This causes race
-# condition when libgbe.so is compiled for the target.
-PARALLEL_MAKE = ""
 
 inherit cmake pkgconfig
 


### PR DESCRIPTION
Enable parallel build for beignet by fixing cmake dependencies. Also remove host contamination possibilities by using Python from sysroot instead of Python from build host. This should also help with the incompatible host clang version problem. Also update beignet to use the latest git HEAD.