### PR TITLE
oeqa/selftest: Adds decorators to image-installer script

### DIFF
--- a/meta-refkit/lib/oeqa/selftest/image-installer.py
+++ b/meta-refkit/lib/oeqa/selftest/image-installer.py
@@ -143,10 +143,12 @@ class ImageInstaller(oeSelfTest):
                 status, output = qemu.run_serial(cmd)
                 self.assertEqual(1, status, 'Failed to run command "%s":\n%s' % (cmd, output))
 
+    @testcase(1834)
     def test_install_no_tpm(self):
         """Test image installation under qemu without virtual TPM"""
         self.do_install()
 
+    @testcase(1835)
     def test_install_fixed_password(self):
         """Test image installation under qemu without virtual TPM, using a fixed password"""
         fixed_password = get_bb_var('REFKIT_DISK_ENCRYPTION_PASSWORD')
@@ -154,6 +156,7 @@ class ImageInstaller(oeSelfTest):
             self.skipTest('REFKIT_DISK_ENCRYPTION_PASSWORD not set')
         self.do_install(fixed_password=fixed_password)
 
+    @testcase(1836)
     def test_install_tpm(self):
-        """Test image installation under qemu without virtual TPM, using a fixed password"""
+        """Test image installation under qemu with virtual TPM, using a fixed password"""
         self.do_install(tpm=True)


### PR DESCRIPTION
Added decorators to test_install_no_tpm, test_install_fixed_password and
test_install_tpm, also correction of typo error on test_install_tpm.
Tracked test cases on bugzilla are at:
test_install_no_tpm -1834 - https://bugzilla.yoctoproject.org/tr_show_case.cgi?case_id=1834
test_install_fixed_password - 1835 - https://bugzilla.yoctoproject.org/tr_show_case.cgi?case_id=1835
test_install_tpm - 1836 - https://bugzilla.yoctoproject.org/tr_show_case.cgi?case_id=1836

Signed-off-by: Francisco Pedraza <francisco.j.pedraza.gonzalez@intel.com>