### PR TITLE
packagegroup-core-connectivity.bb: include libnss-myhostname

### DIFF
--- a/meta-refkit-core/recipes-core/packagegroups/packagegroup-core-connectivity.bb
+++ b/meta-refkit-core/recipes-core/packagegroups/packagegroup-core-connectivity.bb
@@ -10,3 +10,5 @@ RDEPENDS_${PN} = "\
     bluez5-obex \
     connman \
     "
+# Poky doesn't feature systemd so add libnss-myhostname conditionally
+RDEPENDS_${PN}_append_refkit-config = " libnss-myhostname"


### PR DESCRIPTION
The /etc/nsswitch.conf file lists the myhostname plugin
as enabled for resolving hostnames, but all Refkit images
lack it. This makes commands like

  $ ping `hostname`

fail.

Include the plugin in the core connectivity configuration.

Fixes: [YOCTO #11588]

Signed-off-by: Dmitry Rozhkov <dmitry.rozhkov@linux.intel.com>