### PR TITLE
python: runtime and packaging changes

### DIFF
--- a/meta-refkit-core/recipes-core/packagegroups/packagegroup-python-runtime.bb
+++ b/meta-refkit-core/recipes-core/packagegroups/packagegroup-python-runtime.bb
@@ -4,5 +4,5 @@ LICENSE = "MIT"
 inherit packagegroup
 
 RDEPENDS_${PN} = " \
-    python-modules \
+    python3-modules \
 "

--- a/meta-refkit-core/recipes-devtools/python/refkit-python.inc
+++ b/meta-refkit-core/recipes-devtools/python/refkit-python.inc
@@ -3,7 +3,7 @@
 # have this configurable, here it only depends on the "refkit-config"
 # distro feature.
 DEPENDS_remove_refkit-config = "readline gdbm db"
-PACKAGES_remove_refkit-config = "${PN}-readline"
-PROVIDES_remove_refkit-config = "${PN}-readline"
+PACKAGES_remove_refkit-config = "${PN}-readline ${PN}-gdbm ${PN}-db"
+PROVIDES_remove_refkit-config = "${PN}-readline ${PN}-gdbm ${PN}-db"
 RRECOMMENDS_${PN}-core_remove_refkit-config = "${PN}-readline"
-RDEPENDS_${PN}-modules_remove_refkit-config = "${PN}-readline"
+RDEPENDS_${PN}-modules_remove_refkit-config = "${PN}-readline ${PN}-gdbm ${PN}-db"


### PR DESCRIPTION
After dropping gdbm and db from DEPENDS, we also need to
make sure the corresponding ${PN}-* packages don't get
added in PACKAGES/PROVIDES/RDEPENDS.

Without this, the package managers run into dependency issues
when installing, e.g., python(3)-modules that depend on
existent packages.

While we're at it, it's good time to move python-runtime image
feature to use Python3.

Signed-off-by: Mikko Ylinen <mikko.ylinen@linux.intel.com>