### PR TITLE
meta-iotqa: add gstreamer commandline tests

### DIFF
--- a/meta-iotqa/conf/test/refkit-image-computervision.manifest
+++ b/meta-iotqa/conf/test/refkit-image-computervision.manifest
@@ -1,3 +1,4 @@
 # Tests for computervision profile
 oeqa.runtime.multimedia.realsense.realsense_headless
 oeqa.runtime.multimedia.opencl.opencl_viennacl_1
+oeqa.runtime.multimedia.gstreamer.gstreamer_cli

--- a/meta-iotqa/lib/oeqa/runtime/multimedia/gstreamer/gstreamer_cli.py
+++ b/meta-iotqa/lib/oeqa/runtime/multimedia/gstreamer/gstreamer_cli.py
@@ -13,6 +13,6 @@ class GstreamerCommandlineTest(oeRuntimeTest):
         (status, output) = self.target.run('gst-launch-1.0 -v fakesrc silent=false num-buffers=3 ! fakesink silent=false')
         self.assertEqual(status, 0, msg="Error messages: %s" % output)
 
-    def test_gst_launch_cmd_can_create_pipeline_for_video(self):
-        (status, output) = self.target.run('gst-launch-1.0 -v videotestsrc ! videoconvert ! autovideosink')
-        self.assertEqual(status, 0, msg="Error messages: %s" % output)
+    #def test_gst_launch_cmd_can_create_pipeline_for_video(self):
+    #    (status, output) = self.target.run('gst-launch-1.0 -v videotestsrc ! videoconvert ! autovideosink')
+    #    self.assertEqual(status, 0, msg="Error messages: %s" % output)

--- a/meta-iotqa/lib/oeqa/runtime/multimedia/gstreamer/gstreamer_cli.py
+++ b/meta-iotqa/lib/oeqa/runtime/multimedia/gstreamer/gstreamer_cli.py
@@ -1,18 +1,17 @@
 from oeqa.oetest import oeRuntimeTest
 
 class GstreamerCommandlineTest(oeRuntimeTest):
-    def test_gst_inspect_cmd_enabled(self):
+    def test_gst_inspect_can_detect_existing_element(self):
         (status, output) = self.target.run('gst-inspect-1.0')
         self.assertEqual(status, 0, msg="Error messages: %s" % output)
 
-    def test_gst_inspect_cmd_can_detect_existing_element(self):
         (status, output) = self.target.run('gst-inspect-1.0 fakesrc')
         self.assertEqual(status, 0, msg="Error messages: %s" % output)
 
-    def test_gst_launch_cmd_enabled(self):
+    def test_gst_launch_can_create_video_pipeline(self):
+        (status, output) = self.target.run('gst-launch-1.0 -v fakesrc')
+        self.assertEqual(status, 0, msg="Error messages: %s" % output)
+
         (status, output) = self.target.run('gst-launch-1.0 -v fakesrc silent=false num-buffers=3 ! fakesink silent=false')
         self.assertEqual(status, 0, msg="Error messages: %s" % output)
 
-    #def test_gst_launch_cmd_can_create_pipeline_for_video(self):
-    #    (status, output) = self.target.run('gst-launch-1.0 -v videotestsrc ! videoconvert ! autovideosink')
-    #    self.assertEqual(status, 0, msg="Error messages: %s" % output)

--- a/meta-iotqa/lib/oeqa/runtime/multimedia/gstreamer/gstreamer_cli.py
+++ b/meta-iotqa/lib/oeqa/runtime/multimedia/gstreamer/gstreamer_cli.py
@@ -9,9 +9,6 @@ class GstreamerCommandlineTest(oeRuntimeTest):
         self.assertEqual(status, 0, msg="Error messages: %s" % output)
 
     def test_gst_launch_can_create_video_pipeline(self):
-        (status, output) = self.target.run('gst-launch-1.0 -v fakesrc')
-        self.assertEqual(status, 0, msg="Error messages: %s" % output)
-
         (status, output) = self.target.run('gst-launch-1.0 -v fakesrc silent=false num-buffers=3 ! fakesink silent=false')
         self.assertEqual(status, 0, msg="Error messages: %s" % output)
 

--- a/meta-iotqa/lib/oeqa/runtime/multimedia/gstreamer/gstreamer_cli.py
+++ b/meta-iotqa/lib/oeqa/runtime/multimedia/gstreamer/gstreamer_cli.py
@@ -1,0 +1,18 @@
+from oeqa.oetest import oeRuntimeTest
+
+class GstreamerCommandlineTest(oeRuntimeTest):
+    def test_gst_inspect_cmd_enabled(self):
+        (status, output) = self.target.run('gst-inspect-1.0')
+        self.assertEqual(status, 0, msg="Error messages: %s" % output)
+
+    def test_gst_inspect_cmd_can_detect_existing_element(self):
+        (status, output) = self.target.run('gst-inspect-1.0 fakesrc')
+        self.assertEqual(status, 0, msg="Error messages: %s" % output)
+
+    def test_gst_launch_cmd_enabled(self):
+        (status, output) = self.target.run('gst-launch-1.0 -v fakesrc silent=false num-buffers=3 ! fakesink silent=false')
+        self.assertEqual(status, 0, msg="Error messages: %s" % output)
+
+    def test_gst_launch_cmd_can_create_pipeline_for_video(self):
+        (status, output) = self.target.run('gst-launch-1.0 -v videotestsrc ! videoconvert ! autovideosink')
+        self.assertEqual(status, 0, msg="Error messages: %s" % output)


### PR DESCRIPTION
Add gstreamer commandline test to runtime/multimedia/gstreamer.
Add gstreamer commandline test to computer vision manifest.  