### PR TITLE
oe-init-build-env: fix Bash version inconsistencies

### DIFF
--- a/oe-init-build-env
+++ b/oe-init-build-env
@@ -27,10 +27,8 @@
 #
 if [ -n "$BASH_SOURCE" ]; then
     THIS_SCRIPT=$BASH_SOURCE
-elif [ -n "$ZSH_NAME" ]; then
-    THIS_SCRIPT=$0
 else
-    THIS_SCRIPT="$(pwd)/oe-init-build-env"
+    THIS_SCRIPT=$0
 fi
 
 THIS_SCRIPT_DIR=$(dirname "$THIS_SCRIPT")


### PR DESCRIPTION
Some versions* of Bash do not seem to set BASH_SOURCE
correctly resulting broken THIS_SCRIPT path and the
build environment setup fails.

Simplify the if elsif else logic to default to $0 if
BASH_SOURCE is not set.

Tested on:
   * GNU bash, version 4.3.30(1)
   * GNU bash, version 4.4.11(1)
   * zsh 5.0.7

[YOCTO: #11640]

* Bash 4.3.48(1) on Ubuntu 16.04 this fails but with Bash
4.2.46(1) on CentOS 7 it works.

Signed-off-by: Mikko Ylinen <mikko.ylinen@linux.intel.com>