### PR TITLE
CI: add pre- and post-test results publish and reporting

### DIFF
--- a/docker/build-project.sh
+++ b/docker/build-project.sh
@@ -32,9 +32,8 @@ set -u
 
 if [ ! -z ${JOB_NAME+x} ]; then
   # in CI run only:
-  # get commit ID for using in buildhistory tagging, save for later use
+  # get commit ID for using in buildhistory tagging
   CI_GIT_COMMIT=$(git rev-parse HEAD)
-  echo ${CI_GIT_COMMIT} > ${WORKSPACE}/ci_git_commit
 
   # Prepare for buildhistory generation in BH branch, name of which
   # is composed from JOB_NAME and TARGET_MACHINE

--- a/docker/opensuse-42.2/Dockerfile
+++ b/docker/opensuse-42.2/Dockerfile
@@ -11,6 +11,7 @@ RUN zypper --no-color --non-interactive ref -f && \
             gcc-c++ git chrpath make wget python-xml diffstat makeinfo \
             python-curses patch socat libSDL-devel tar which unzip \
             net-tools iproute2 vim netcat-openbsd \
+            python3-unittest-xml-reporting python3-six \
             python3 python3-curses glibc-locale syslinux
 
 ENV JENKINS_HOME /var/lib/jenkins

--- a/docker/pre-build.sh
+++ b/docker/pre-build.sh
@@ -45,7 +45,5 @@ _tests=`grep REFKIT_CI_PREBUILD_SELFTESTS ${WORKSPACE}/refkit_ci_vars | perl -pe
 if [ -n "$_tests" ]; then
   oe-selftest --run-tests ${_tests}
 fi
-# remove build/ dir to clean tester-related config and results
-rm -fr ${WORKSPACE}/build
-
-
+# build/ should not pollute next stages: don't delete, it has test results
+mv -f ${WORKSPACE}/build ${WORKSPACE}/build.pre

--- a/docker/tester-create-summary.sh
+++ b/docker/tester-create-summary.sh
@@ -1,0 +1,43 @@
+#
+# tester-create-summary.sh: tester creates summary information
+# Copyright (c) 2016, Intel Corporation.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms and conditions of the GNU General Public License,
+# version 2, as published by the Free Software Foundation.
+#
+# This program is distributed in the hope it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+
+declare -i num_total=0 num_skipped=0 num_na=0 num_failed=0 num_error=0
+_image=$1
+_device=$2
+_reports_basename=$3
+_num_masked=$4
+
+# create piece of summary for composing email notification
+_reports=`ls ${_reports_basename}*.xml`
+num_na=$_num_masked
+for _r in $_reports; do
+    _s=`grep 'testsuite errors=' $_r |tr -d '<>' |sed 's/testsuite//g'`
+    eval $_s
+    num_error+=${errors}
+    num_failed+=${failures}
+    num_skipped+=${skipped}
+    num_total+=${tests}
+done
+num_passed=$((num_total - num_error - num_failed - num_skipped))
+run_total=$((num_passed + num_failed))
+echo "${_image}"
+[ -n "$_device" ] && echo "  Device: ${_device}"
+echo "  Total:$num_total  Pass:$num_passed  Fail:$num_failed  Skip:$num_skipped  Error:$num_error  N/A:$num_na"
+if [ $num_total -gt 0 ]; then
+    run_rate=$((100*run_total/num_total))
+    pass_rate_of_total=$((100*num_passed/num_total))
+    pass_rate_of_exec=$((100*num_passed/run_total))
+    echo "  Run rate:${run_rate}%  Pass rate of total:${pass_rate_of_total}%  Pass rate of exec:${pass_rate_of_exec}%"
+fi
+echo "-------------------------------------------------------------------"


### PR DESCRIPTION
python3-unittest-xml-reporting and python-six packages are needed in Docker session
to make XML test-reports to be saved from post-tests.

In Jenkinsfile we will publish TEST-*.xml files produced in post-build stage.

Better git values handling: Create git ci_commit_id and commit list after check-out,
remove cross-layer-use of ci_git_commit

Signed-off-by: Olev Kartau <olev.kartau@intel.com>