### PR TITLE
openembedded-core submodule update

### DIFF
--- a/meta-refkit-core/scripts/lib/wic/plugins/source/dm-verity.py
+++ b/meta-refkit-core/scripts/lib/wic/plugins/source/dm-verity.py
@@ -33,7 +33,7 @@ import tempfile
 
 from wic import WicError
 from wic.pluginbase import SourcePlugin
-from wic.utils.misc import (exec_cmd, exec_native_cmd, get_bitbake_var)
+from wic.misc import (exec_cmd, exec_native_cmd, get_bitbake_var)
 
 logger = logging.getLogger('wic')
 


### PR DESCRIPTION
wic was reorganized, so this particular update has to be done in
combination with updating the dm-verity.py wic plugin.

There's no particular need for the update, I just happened to notice
that further work is needed and thus did it.