### PR TITLE
flatpak-enable the stock gateway image

### DIFF
--- a/meta-iotqa/conf/test/refkit-image-gateway.manifest
+++ b/meta-iotqa/conf/test/refkit-image-gateway.manifest
@@ -5,3 +5,5 @@ oeqa.runtime.peripherals.mraa.mraa_gpio
 oeqa.runtime.peripherals.mraa.mraa_hello
 oeqa.runtime.peripherals.upm.upm
 oeqa.runtime.programming.nodejs.apprt_nodejs
+oeqa.runtime.sanity.flatpak
+oeqa.runtime.sanity.flatpak-session

--- a/meta-refkit-gateway/README.rst
+++ b/meta-refkit-gateway/README.rst
@@ -32,8 +32,8 @@ Patches
 See the "Submitting Patches" section in the top-level ``README.rst``.
 
 
-Adding the refkit-computervision layer to your build
-====================================================
+Adding the refkit-gateway layer to your build
+=============================================
 
 See the "Layer Overview and Reuse" section in ``doc/introduction.rst``
 for details.

--- a/meta-refkit-gateway/recipes-image/images/refkit-image-gateway.bb
+++ b/meta-refkit-gateway/recipes-image/images/refkit-image-gateway.bb
@@ -11,6 +11,7 @@ REFKIT_IMAGE_GATEWAY_EXTRA_FEATURES += " \
     iotivity \
     nodejs-runtime \
     sensors \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'flatpak', 'flatpak', '', d)} \
 "
 
 # Example for customization in local.conf when building

--- a/meta-refkit/conf/distro/include/refkit-ci.inc
+++ b/meta-refkit/conf/distro/include/refkit-ci.inc
@@ -78,8 +78,6 @@ REFKIT_CI_SDK_TARGETS=""
 REFKIT_CI_ESDK_TARGETS=""
 # Following targets would be executed with do_test_iot_export task
 REFKIT_CI_TEST_EXPORT_TARGETS="refkit-image-common refkit-image-computervision refkit-image-gateway refkit-image-industrial \
-${@bb.utils.contains('DISTRO_FEATURES', 'flatpak', \
-    'refkit-image-gateway-flatpak-runtime', '', d)} \
 "
 
 # Execute automatic tests for following images with corresponding
@@ -96,8 +94,6 @@ REFKIT_CI_TEST_RUNS=" \
   refkit-image-gateway,iot-testsuite.tar.gz,iot-testfiles.${MACHINE}.tar.gz,${MACHINE},minnowboardturbot \
   refkit-image-industrial,iot-testsuite.tar.gz,iot-testfiles.${MACHINE}.tar.gz,${MACHINE},570x \
   refkit-image-industrial,iot-testsuite.tar.gz,iot-testfiles.${MACHINE}.tar.gz,${MACHINE},minnowboardturbot \
-  ${@bb.utils.contains('DISTRO_FEATURES', 'flatpak', \
-      'refkit-image-gateway-flatpak-runtime,iot-testsuite.tar.gz,iot-testfiles.${MACHINE}.tar.gz,${MACHINE},minnowboardturbot', '', d)} \
 "
 
 # Dont use disk space monitor in CI builds, to avoid frequent


### PR DESCRIPTION
This patch set enables flatpak support for the stock gateway image. IOW it essentially turns the stock refkit-image-gateway into refkit-image-gateway-flatpak-runtime, as long as the required flatpak distro features are enabled. Consequently, the patches also remove building and testing the explicitly spelled out flatpak variant of the same image in CI.