### PR TITLE
log command output

### DIFF
--- a/meta-refkit-core/lib/oeqa/selftest/cases/image_installer.py
+++ b/meta-refkit-core/lib/oeqa/selftest/cases/image_installer.py
@@ -59,9 +59,7 @@ class ImageInstaller(OESelftestTestCase):
             # temporarily in a way that it overrides some other IMAGE_MODE setting in local.conf.
             self.append_config('IMAGE_MODE_forcevariable = "development"')
             targets = 'refkit-installer-image ovmf swtpm-wrappers-native'
-            print('Starting: bitbake %s' % targets)
-            result = bitbake(targets)
-            print(result.output)
+            result = bitbake(targets, output_log=self.logger)
             ImageInstaller.image_is_ready = True
 
         # We create the directory under ${TMPDIR} and thus can avoid

--- a/meta-refkit-core/lib/oeqa/selftest/cases/refkit_license_check.py
+++ b/meta-refkit-core/lib/oeqa/selftest/cases/refkit_license_check.py
@@ -115,7 +115,7 @@ class LicensingTest(OESelftestTestCase):
 
         # Create the root filesystem. It's enough for getting a package
         # list.
-        bitbake('-c rootfs %s' % test_image)
+        bitbake('-c rootfs %s' % test_image, output_log=self.logger)
 
         # Find package list manifest.
         manifest = self._get_latest_manifest(imagename, deploydir)

--- a/meta-refkit-core/lib/oeqa/selftest/systemupdate/systemupdatebase.py
+++ b/meta-refkit-core/lib/oeqa/selftest/systemupdate/systemupdatebase.py
@@ -250,8 +250,7 @@ ROOTFS_POSTPROCESS_COMMAND += "system_update_test_modify;"
         self.write_config('BBFILES_append = " %s"' % os.path.abspath(self.IMAGE_BBAPPEND))
         create_image_bbappend(False)
         self.logger.info('Building base image')
-        result = bitbake(self.IMAGE_PN)
-        self.logger.info('bitbake output: %s' % result.output)
+        result = bitbake(self.IMAGE_PN, output_log=self.logger)
 
         # Copying the entire deploy directory via hardlinks is relatively cheap
         # and gives us everything required to run qemu.
@@ -264,7 +263,7 @@ ROOTFS_POSTPROCESS_COMMAND += "system_update_test_modify;"
         # during the next rebuild.
         create_image_bbappend(True)
         self.logger.info('Building updated image')
-        bitbake(self.IMAGE_PN)
+        bitbake(self.IMAGE_PN, output_log=self.logger)
 
         # Change DEPLOY_DIR_IMAGE so that we use our copy of the
         # images from before the update. Further customizations for booting can

--- a/meta-refkit/conf/distro/include/refkit-ci.inc
+++ b/meta-refkit/conf/distro/include/refkit-ci.inc
@@ -51,7 +51,8 @@ REFKIT_VM_IMAGE_TYPES ?= "wic.xz wic.bmap"
 # pre/post-build oe-selftests started by CI builder, whitespace-separated.
 #
 REFKIT_CI_PREBUILD_SELFTESTS="iotsstatetests.SStateTests.test_sstate_samesigs"
-# NB: run image-installer last until YOCTO #11443 gets fixed.
+# https://bugzilla.yoctoproject.org/show_bug.cgi?id=11756 currently causes
+# oe-selftest to ignore the order.
 REFKIT_CI_POSTBUILD_SELFTESTS="secureboot refkit_poky refkit_license_check refkit_ostree.RefkitOSTreeUpdateTestAll image_installer"
 #
 # Automated build targets

--- a/meta-refkit/lib/oeqa/selftest/cases/refkit_poky.py
+++ b/meta-refkit/lib/oeqa/selftest/cases/refkit_poky.py
@@ -265,7 +265,7 @@ class TestRefkitPokyBuilds(TestRefkitPokyBase):
         self.append_config('''
 REFKIT_IMAGE_EXTRA_FEATURES_append = " empty-root-password"
 ''')
-        bitbake('refkit-image-common')
+        bitbake('refkit-image-common', output_log=self.logger)
         with runqemu('refkit-image-common',
                      ssh=False,
                      image_fstype='wic',
@@ -288,7 +288,7 @@ REFKIT_IMAGE_EXTRA_FEATURES_append = " empty-root-password"
 require conf/distro/include/enable-refkit-config.inc
 REFKIT_IMAGE_MODE = "development"
 ''')
-        bitbake('refkit-image-common')
+        bitbake('refkit-image-common', output_log=self.logger)
         with runqemu('refkit-image-common',
                      ssh=False,
                      image_fstype='wic',

--- a/meta-refkit/lib/oeqa/selftest/cases/secureboot.py
+++ b/meta-refkit/lib/oeqa/selftest/cases/secureboot.py
@@ -46,11 +46,7 @@ class SecureBootTests(OESelftestTestCase):
     def setUpLocal(self):
 
         if not SecureBootTests.ovmf_keys_enrolled:
-            print('\n')
-            print('Building ovmf-shell-image-enrollkeys')
-            bitbake('ovmf-shell-image-enrollkeys')
-            print('Building ovmf')
-            bitbake('ovmf')
+            bitbake('ovmf ovmf-shell-image-enrollkeys', output_log=self.logger)
 
             bb_vars = get_bb_vars(['TMPDIR', 'DEPLOY_DIR_IMAGE'])
 
@@ -80,14 +76,11 @@ class SecureBootTests(OESelftestTestCase):
     def tearDownLocal(self):
         # Seems this is mandatory between the tests (a signed image is booted
         # when running test_boot_unsigned_image after test_boot_signed_image).
-        print('Cleaning...%s' % self.test_image)
-        bitbake('-c clean %s' % self.test_image)
+        bitbake('-c clean %s' % self.test_image, output_log=self.logger)
 
     @classmethod
     def tearDownClass(self):
-
-        print('Cleaning...')
-        bitbake('ovmf-shell-image-enrollkeys:do_cleanall')
+        bitbake('ovmf-shell-image-enrollkeys:do_cleanall', output_log=self.logger)
         rmtree(self.ovmf_dir, ignore_errors=True)
 
     def secureboot_with_image(self, signing_key="", efishell=False, boot_timeout=600):
@@ -103,10 +96,8 @@ class SecureBootTests(OESelftestTestCase):
             config += 'REFKIT_IMAGE_EXTRA_FEATURES_append = " secureboot"\n'
             config += 'REFKIT_IMAGE_EXTRA_INSTALL_append = " efivar"\n'
 
-        print('Building %s' % self.test_image)
-
         self.write_config(config)
-        bitbake(self.test_image)
+        bitbake(self.test_image, output_log=self.logger)
         self.remove_config(config)
 
         # Some of the cases depend on the timeout to expire. Allow overrides


### PR DESCRIPTION
With the recently enhanced runCmd/bitbake() in OE-core master we can get
output from the invoked command passed through the logger that each test
has, which provides much nicer output while a test runs: instead of of test
that just seems to hang, one gets a constant stream of messages with time
stamps.

The command also gets logged, so we can remove some extra output which now
is a bit redundant.