### PR TITLE
refkit: reconfigure meta-ros in refkit-config.inc

### DIFF
--- a/meta-refkit-core/conf/distro/include/refkit-config.inc
+++ b/meta-refkit-core/conf/distro/include/refkit-config.inc
@@ -109,6 +109,9 @@ PREFERRED_PROVIDER_virtual/opencl-headers-cxx_df-refkit-config = "opencl-headers
 # remove readline support from Bluez to reduce GPLv3 dependencies
 BAD_RECOMMENDATIONS_append_df-refkit-config = " bluez5-client"
 
+# Make ROS use python3 to run its core scripts
+ROS_USE_PYTHON3_df-refkit-config = "yes"
+
 ########################################################################
 # Changes that can be done via PACKAGECONFIG are meant to be done
 # here instead of via .bbappends. SECURITY_* changes go into

--- a/meta-refkit/conf/distro/refkit.conf
+++ b/meta-refkit/conf/distro/refkit.conf
@@ -194,6 +194,3 @@ PACKAGE_ARCH_pn-rhino = "${TUNE_PKGARCH}"
 # re-use uninative shim released by Yocto Project / OE
 require conf/distro/include/yocto-uninative.inc
 INHERIT += "uninative"
-
-# Make ROS use python3 to run its core scripts
-ROS_USE_PYTHON3 = "yes"


### PR DESCRIPTION
Setting ROS_USE_PYTHON3 in refkit-config.inc is better because:
- other distros may also need that setting
- all content re-configuration is one one place and thus
  easier to review

Signed-off-by: Patrick Ohly <patrick.ohly@intel.com>