### PR TITLE
avoid netcat dependency

### DIFF
--- a/docker/opensuse-42.2/Dockerfile
+++ b/docker/opensuse-42.2/Dockerfile
@@ -10,7 +10,7 @@ RUN zypper --no-color --non-interactive ref -f && \
     zypper --no-color --non-interactive install --no-recommends python gcc \
             gcc-c++ git chrpath make wget python-xml diffstat makeinfo \
             python-curses patch socat libSDL-devel tar which unzip \
-            net-tools iproute2 vim netcat-openbsd \
+            net-tools iproute2 vim \
             python3-unittest-xml-reporting python3-six \
             python3 python3-curses glibc-locale syslinux
 


### PR DESCRIPTION
Usage of the host netcat can be replaced by building socat-native.
Should fix PR #221.