### PR TITLE
util-linux_%.bbappend: remove obsolete nologin workaround

### DIFF
--- a/meta-refkit-core/bbappends/openembedded-core/meta/recipes-core/util-linux/util-linux_%.bbappend
+++ b/meta-refkit-core/bbappends/openembedded-core/meta/recipes-core/util-linux/util-linux_%.bbappend
@@ -7,20 +7,3 @@ DEPENDS_remove_class-native_df-refkit-config = "lzo-native"
 DEPENDS_remove_class-nativesdk_df-refkit-config = "lzo-native"
 DEPENDS_append_class-native_df-refkit-config = " lz4-native"
 DEPENDS_append_class-nativesdk_df-refkit-config = " lz4-native"
-
-# nologin can come from two separate sources, shadow and util-linux.
-# Normally these do not conflict, the one from shadow goes into /sbin,
-# the one from util-linux goes into /usr/sbin. With usrmerge enabled,
-# however, /sbin is symlinked to /usr/sbin and these start conflicting.
-# If that happens, we make util-linux get out of the way by removing
-# its nologin.
-#
-# Ideally we probably should make sure first that shadow is enabled to
-# ensure we don't end up without any /{usr/,}sbin/nologin.
-
-do_install_append_df-refkit-config () {
-    if [ -n "${@bb.utils.contains('DISTRO_FEATURES', 'usrmerge', 'y', '', d)}" ];
-    then
-        rm -f ${D}${sbindir}/nologin
-    fi
-}


### PR DESCRIPTION
Upstream OE-core has this fix for the issue:

  commit 07d6d0fb4dc689008bb0022d7d2ecc890c9159e5
  Author: Amarnath Valluri <amarnath.valluri@intel.com>
  Date:   Tue Jan 24 16:07:20 2017 +0200

    util-linux,shadow: Make 'nologin' alternative command

    Both shadow and util-linux packages provides 'nologin' binary in ${base_sbindir}
    and ${sbindir} respectively, this leads to conflict when 'usrmerge' feature is
    enabled, where ${sbindir} == ${base_sbindir}. Hance, handle this to alternative
    system to resolve the conflict.

Signed-off-by: Patrick Ohly <patrick.ohly@intel.com>