### PR TITLE
Move to gcc 7.1

### DIFF
--- a/meta-refkit-computervision/recipes-computervision/librealsense/files/0001-Add-missing-includes-for-functional.patch
+++ b/meta-refkit-computervision/recipes-computervision/librealsense/files/0001-Add-missing-includes-for-functional.patch
@@ -1,0 +1,42 @@
+From 7b1581644c5fbdec3a22cd512557b391dc74ebf0 Mon Sep 17 00:00:00 2001
+From: Till Hofmann <thofmann@fedoraproject.org>
+Date: Wed, 22 Mar 2017 14:23:24 +0100
+Subject: [PATCH] Add missing includes for <functional>
+
+Newer GCC versions (>=7) fail with an error if the header is not
+included an std::function is used.
+
+Upstream-Status: Backport [https://github.com/IntelRealSense/librealsense/commit/7b1581644c5fbdec3a22cd512557b391dc74ebf0]
+
+---
+ src/device.cpp | 1 +
+ src/types.h    | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/src/device.cpp b/src/device.cpp
+index 2194769..8918cb1 100644
+--- a/src/device.cpp
++++ b/src/device.cpp
+@@ -11,6 +11,7 @@
+ #include <algorithm>
+ #include <sstream>
+ #include <iostream>
++#include <functional>
+ 
+ using namespace rsimpl;
+ using namespace rsimpl::motion_module;
+diff --git a/src/types.h b/src/types.h
+index 0455c83..a964bf3 100644
+--- a/src/types.h
++++ b/src/types.h
+@@ -22,6 +22,7 @@
+ #include <atomic>
+ #include <map>          
+ #include <algorithm>
++#include <functional>
+ 
+ const uint8_t RS_STREAM_NATIVE_COUNT    = 5;
+ const int RS_USER_QUEUE_SIZE = 20;
+-- 
+2.1.4
+

--- a/meta-refkit-computervision/recipes-computervision/librealsense/librealsense_%.bbappend
+++ b/meta-refkit-computervision/recipes-computervision/librealsense/librealsense_%.bbappend
@@ -10,6 +10,7 @@ PACKAGES_df-refkit-computervision = "${PN} ${PN}-dbg ${PN}-dev ${PN}-examples ${
 SRC_URI_append_df-refkit-computervision = " \
     file://0001-scripts-removed-bashisms.patch \
     file://0001-examples-control-building-of-the-graphical-examples.patch \
+    file://0001-Add-missing-includes-for-functional.patch \
 "
 
 RDEPENDS_${PN}_remove_df-refkit-computervision = "bash"

--- a/meta-refkit-core/conf/distro/include/refkit-config.inc
+++ b/meta-refkit-core/conf/distro/include/refkit-config.inc
@@ -47,6 +47,9 @@ REFKIT_DEFAULT_DISTRO_FEATURES += "refkit-firewall"
 # Reconfigure several upstream recipes for the computer vision profile.
 REFKIT_DEFAULT_DISTRO_FEATURES += "refkit-computervision"
 
+# Reconfigure/patch upstream recipes for the gateway vision profile.
+REFKIT_DEFAULT_DISTRO_FEATURES += "refkit-gateway"
+
 # Reconfigure several upstream recipes for the industrial profile.
 REFKIT_DEFAULT_DISTRO_FEATURES += "refkit-industrial"
 

--- a/meta-refkit-core/conf/distro/include/refkit-config.inc
+++ b/meta-refkit-core/conf/distro/include/refkit-config.inc
@@ -79,10 +79,6 @@ DISTRO_FEATURES_OVERRIDES += " \
 # Global distro settings.
 #########################################################################
 
-# Several components that refkit depends on aren't ready for gcc7 yet.
-# Can be overridden in local.conf with GCCVERSION_df-refkit-config = "7.%"
-GCCVERSION_df-refkit-config ??= "6.3%"
-
 # refkit images distinguish between development and production mode.
 # Features that are useful only for development and dangerous
 # when used on real devices are not enabled in production mode (example:

--- a/meta-refkit-gateway/recipes-core/iotivity/files/0001-resource-Include-functional-header-for-g-7.1.0.patch
+++ b/meta-refkit-gateway/recipes-core/iotivity/files/0001-resource-Include-functional-header-for-g-7.1.0.patch
@@ -1,0 +1,61 @@
+From 26c2798188497da22e0a70efebc47991dd755db2 Mon Sep 17 00:00:00 2001
+From: Philippe Coval <philippe.coval@osg.samsung.com>
+Date: Wed, 28 Jun 2017 04:54:05 +0200
+Subject: [PATCH] resource: Include functional header for g++-7.1.0
+
+It was tested on yocto poky master on iotivity-1.2.1 (and later):
+
+  resource/include/OCUtilities.h: \
+  In function 'OCStackResult OC::nil_guard(PtrT&&, FnT&&, ParamTs&& ...)':
+  resource/include/OCUtilities.h:85:21: \
+  error: 'bind' is not a member of 'std'
+  return std::bind(fn, p, std::ref(params)...)();
+
+  resource/include/OCApi.h: At global scope:
+  resource/include/OCApi.h:362:18: \
+  error: 'function' in namespace 'std' does not name a template type
+  typedef std::function<void(std::shared_ptr<OCResource>)> FindCallback;
+
+Change-Id: Ie1cab497c33fde394f77490a1d636eb36a563396
+Origin: https://gerrit.iotivity.org/gerrit/#/c/21069/
+Signed-off-by: Philippe Coval <philippe.coval@osg.samsung.com>
+Reviewed-on: https://gerrit.iotivity.org/gerrit/21067
+Reviewed-by: Thiago Macieira <thiago.macieira@intel.com>
+Tested-by: jenkins-iotivity <jenkins@iotivity.org>
+
+Upstream-Status: Backport [https://gerrit.iotivity.org/gerrit/gitweb?p=iotivity.git;a=commit;h=cedb81a54e08e56f4a0ffac9c318a0b1b1623239]
+
+---
+ resource/include/OCApi.h       | 2 --
+ resource/include/OCUtilities.h | 1 +
+ 2 files changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/resource/include/OCApi.h b/resource/include/OCApi.h
+index 4e14f29..af97215 100644
+--- a/resource/include/OCApi.h
++++ b/resource/include/OCApi.h
+@@ -27,9 +27,7 @@
+ #include <map>
+ #include <memory>
+ #include <iterator>
+-#if defined(_MSC_VER)
+ #include <functional>
+-#endif
+ 
+ #include "iotivity_config.h"
+ #include "iotivity_debug.h"
+diff --git a/resource/include/OCUtilities.h b/resource/include/OCUtilities.h
+index 85039d0..f1c9304 100644
+--- a/resource/include/OCUtilities.h
++++ b/resource/include/OCUtilities.h
+@@ -26,6 +26,7 @@
+ #include <memory>
+ #include <utility>
+ #include <exception>
++#include <functional>
+ 
+ #include <OCException.h>
+ #include <StringConstants.h>
+-- 
+2.1.4
+

--- a/meta-refkit-gateway/recipes-core/iotivity/iotivity_%.bbappend
+++ b/meta-refkit-gateway/recipes-core/iotivity/iotivity_%.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI_append_df-refkit-gateway = " \
+    file://0001-resource-Include-functional-header-for-g-7.1.0.patch \
+"


### PR DESCRIPTION
Many fixes (including meta-ros GCC7.1 readiness) have been merged
so move back to follow OE-core default GCCVERSION.