### PR TITLE
CI Jenkinsfile: Run post-build and DAFT tests in parallel

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,9 +49,7 @@ try {
             ws("workspace/${slot_name}${ci_build_id}") {
                 builder_node = "${env.NODE_NAME}"
                 set_gh_status_pending(is_pr, 'Prepare for build')
-                stage('Cleanup workspace') {
-                    deleteDir()
-                }
+                deleteDir() // although dir should be brand new, empty just in case
                 stage('Checkout content') {
                     checkout_content(is_pr)
                 }


### PR DESCRIPTION
CI Jenkinsfile: Run post-build and DAFT tests in parallel
We can't keep same docker container around for another node stmt,
but we can create a new docker container, which will
use same worktree from build stage. That allows to
put post-build tests into same set with daft-based tests
and run all of those in parallel, thus shortening
the job time by daft-tests duration (which is shorter than
post-build tests duration).

Second change in this PR is:
Stop calling workspace cleaning a stage.
    
After async. cleanup was introduced, deleteDir at start of
each job does practically nothing, but we keep it there just in case.
There is no point however put this short duration up on stages chart.
