### PR TITLE
CI: skip storing of plain .wic files

### DIFF
--- a/docker/publish-project.sh
+++ b/docker/publish-project.sh
@@ -58,7 +58,8 @@ _DEPL=${_BRESULT}/deploy
 
 # create publishing destination structure and copy
 create_remote_dirs ${RSYNC_PUBLISH_DIR}/builds ${JOB_NAME}/${CI_BUILD_ID}
-[ -d ${_DEPL}/images ] && create_remote_dirs ${_RSYNC_DEST} images && rsync -avS ${_DEPL}/images/${TARGET_MACHINE} ${_RSYNC_DEST}/images/
+# no uses for stored plain .wic files, skip storing on server, saving big part of space and transfer time
+[ -d ${_DEPL}/images ] && create_remote_dirs ${_RSYNC_DEST} images && rsync -avS --exclude '*.wic' ${_DEPL}/images/${TARGET_MACHINE} ${_RSYNC_DEST}/images/
 [ -d ${_DEPL}/licenses ] && create_remote_dirs ${_RSYNC_DEST} licenses && rsync -az --ignore-existing ${_DEPL}/licenses ${_RSYNC_DEST}/
 [ -d ${_DEPL}/sources ] && create_remote_dirs ${_RSYNC_DEST} sources && rsync -av --ignore-existing ${_DEPL}/sources ${_RSYNC_DEST}/
 [ -d ${_DEPL}/tools ] && create_remote_dirs ${_RSYNC_DEST} tools && rsync -av --ignore-existing ${_DEPL}/tools ${_RSYNC_DEST}/


### PR DESCRIPTION
publishing of plain .wic files to storage server
takes majority of transfer time and also space on server,
but there is no use for stored plain .wic files as wic.xz
are used.

Signed-off-by: Olev Kartau <olev.kartau@intel.com>