### PR TITLE
CI: retry daft after unstable, fix bashism in summary, fix xml-reports handling, publish more sstate

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -86,8 +86,10 @@ try {
                         throw e
                     } finally {
                         set_gh_status_pending(is_pr, 'Store images')
-                        params = ["${script_env}", "docker/publish-project.sh"].join("\n")
                         stage('Store images') {
+                            params = ["${script_env}", "docker/publish-project.sh"].join("\n")
+                            sh "${params}"
+                            params = ["${script_env}", "docker/publish-sstate.sh"].join("\n")
                             sh "${params}"
                         }
                     }
@@ -107,6 +109,8 @@ try {
                 build_docker_image(image_name)
                 docker.image(image_name).inside(run_args) {
                     params = ["${script_env}", "docker/post-build.sh"].join("\n")
+                    sh "${params}"
+                    params = ["${script_env}", "docker/publish-sstate.sh"].join("\n")
                     sh "${params}"
                 }
                 // note wildcard: handle pre-build reports in build.pre/ as well

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -92,9 +92,6 @@ try {
                         }
                     }
                 } // docker_image
-                archiveArtifacts allowEmptyArchive: true,
-                                 artifacts: 'build*/TestResults_*/TEST-*.xml'
-                step_xunit('build*/TestResults_*/TEST-*.xml')
                 tester_script = readFile "docker/tester-exec.sh"
                 tester_summary = readFile "docker/tester-create-summary.sh"
                 qemu_script = readFile "docker/run-qemu.exp"
@@ -111,6 +108,16 @@ try {
                 docker.image(image_name).inside(run_args) {
                     params = ["${script_env}", "docker/post-build.sh"].join("\n")
                     sh "${params}"
+                }
+                // note wildcard: handle pre-build reports in build.pre/ as well
+                lock(resource: "global_data") {
+                    summary += sh(returnStdout: true,
+                                  script: "docker/tester-create-summary.sh 'oe-selftest: post-build' '' build/TestResults_*/TEST- 0")
+                    archiveArtifacts allowEmptyArchive: true,
+                                     artifacts: 'build*/TestResults_*/TEST-*.xml'
+                }
+                lock(resource: "step-xunit") {
+                    step_xunit('build*/TestResults_*/TEST-*.xml')
                 }
             }
         }

--- a/docker/publish-project.sh
+++ b/docker/publish-project.sh
@@ -114,17 +114,6 @@ if [ -f "${LOG}" ]; then
     rsync -avz ${LOG}* ${_RSYNC_DEST}/
 fi
 
-if [ -d sstate-cache ]; then
-  if [ ! -z ${BUILD_CACHE_DIR+x} ]; then
-    if [ -d ${BUILD_CACHE_DIR}/sstate ]; then
-      # populate shared sstate from local sstate:
-      _src=sstate-cache
-      _dst=${RSYNC_PUBLISH_DIR}/bb-cache/sstate
-      find ${_src} -mindepth 1 -maxdepth 1 -type d -exec rsync -a --ignore-existing {} ${_dst}/ \;
-    fi
-  fi
-fi
-
 ## for debugging signatures: publish stamps
 if [ -d ${_BRESULT}/stamps ]; then
     create_remote_dirs ${_RSYNC_DEST} .stamps/${TARGET_MACHINE}/

--- a/docker/publish-sstate.sh
+++ b/docker/publish-sstate.sh
@@ -1,0 +1,26 @@
+#!/bin/sh -xeu
+#
+# publish-project.sh: Publish local sstate into global sstate
+# Copyright (c) 2017, Intel Corporation.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms and conditions of the GNU General Public License,
+# version 2, as published by the Free Software Foundation.
+#
+# This program is distributed in the hope it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+
+cd $WORKSPACE/build
+
+if [ -d sstate-cache ]; then
+  if [ ! -z ${BUILD_CACHE_DIR+x} ]; then
+    if [ -d ${BUILD_CACHE_DIR}/sstate ]; then
+      # populate shared sstate from local sstate, show names for tracability
+      _src=sstate-cache
+      _dst=${RSYNC_PUBLISH_DIR}/bb-cache/sstate
+      find ${_src} -mindepth 1 -maxdepth 1 -type d -exec rsync -a --info=name --ignore-existing {} ${_dst}/ \;
+    fi
+  fi
+fi

--- a/docker/tester-create-summary.sh
+++ b/docker/tester-create-summary.sh
@@ -1,3 +1,4 @@
+#!/bin/bash -ue
 #
 # tester-create-summary.sh: tester creates summary information
 # Copyright (c) 2016, Intel Corporation.

--- a/docker/tester-exec.sh
+++ b/docker/tester-exec.sh
@@ -111,6 +111,12 @@ testimg() {
 
     daft ${DEVICE} ${FILENAME} --record
     TEST_EXIT_CODE=$?
+    if [ "$TEST_EXIT_CODE" = 1 ]; then
+      echo "WARNING: daft=1 would lead to UNSTABLE: wipe results, retry daft"
+      rm -f *.log *.log.raw *.xml
+      daft ${DEVICE} ${FILENAME} --record
+      TEST_EXIT_CODE=$?
+    fi
   fi
 
   # delete symlinks, these point outside of local set and are useless


### PR DESCRIPTION
It makes sense to retry daft after unstable
result which means problem on tester.

2nd commit here is adding forgotten shebang in tester-create-summary.sh
which created trouble on Ubuntu where this script goes through dash

3rd commit fixes xml-reports handling which got partially broken with
recent parallel-testing change

4th commit is "publish sstate after post-build tests as well"
which was combined into this PR from PR#239

Signed-off-by: Olev Kartau <olev.kartau@intel.com>