### PR TITLE
Update ostree and flatpak to the latest tagged upstream releases.

### DIFF
--- a/meta-flatpak/recipes-flatpak/flatpak/flatpak_git.bb
+++ b/meta-flatpak/recipes-flatpak/flatpak/flatpak_git.bb
@@ -10,9 +10,9 @@ SRC_URI = " \
     file://0003-lib-Allow-passing-command-line-argument-through-laun.patch \
 "
 
-SRCREV = "1a49029f9d8fbee0338665522cf7432ae7485841"
+SRCREV = "9a19ea7c1329d55129898330f5c329ece05c875e"
 
-PV = "0.9.3+git${SRCPV}"
+PV = "0.9.7+git${SRCPV}"
 S = "${WORKDIR}/git"
 
 inherit autotools pkgconfig gettext requires-systemd gobject-introspection

--- a/meta-flatpak/recipes-ostree/ostree/ostree_git.bb
+++ b/meta-flatpak/recipes-ostree/ostree/ostree_git.bb
@@ -9,9 +9,9 @@ SRC_URI = " \
     file://0001-autogen.sh-fall-back-to-no-gtkdocize-if-it-is-there-.patch \
 "
 
-SRCREV = "f3cc0eb25a773d21fdbbb778f1756df5466ff7cf"
+SRCREV = "5a5e465492aca13937dab7a2df39f25da94e6e36"
 
-PV = "2017.5+git${SRCPV}"
+PV = "2017.8+git${SRCPV}"
 S = "${WORKDIR}/git"
 
 inherit autotools pkgconfig requires-systemd gobject-introspection
@@ -45,8 +45,12 @@ EXTRA_OECONF_class-native += " \
 "
 
 # package content
+PACKAGES += "${PN}-systemd-generator"
+
 FILES_${PN} += "${libdir}/girepository-1.0 ${datadir}/gir-1.0"
 SYSTEMD_SERVICE_${PN} = "ostree-prepare-root.service ostree-remount.service"
+
+FILES_${PN}-systemd-generator = "${libdir}/systemd/system-generators"
 
 do_configure_prepend() {
     cd ${S}


### PR DESCRIPTION
Update ostree to v2017.8.
Update flatpak to 0.9.7.