### PR TITLE
Update whitelist layer reference of xf86-video-mga

### DIFF
--- a/meta-refkit/conf/distro/include/refkit-supported-recipes.txt
+++ b/meta-refkit/conf/distro/include/refkit-supported-recipes.txt
@@ -495,7 +495,7 @@ xf86-input-libinput@core
 xf86-video-ast@intel
 xf86-video-fbdev@core
 xf86-video-intel@core
-xf86-video-mga@intel
+xf86-video-mga@openembedded-layer
 xf86-video-vesa@core
 xf86dgaproto@core
 xf86driproto@core


### PR DESCRIPTION
Due to recent BSP changes, whitelist layer reference of xf86-video-mga
package needs to be updated.

Signed-off-by: Jussi Laako <jussi.laako@linux.intel.com>