### PR TITLE
CI: remove sstate debug code

### DIFF
--- a/docker/build-project.sh
+++ b/docker/build-project.sh
@@ -96,10 +96,6 @@ else
   _bitbake_targets="$BUILD_TARGET"
 fi
 
-# Ensure that we have a local sstate signature for all tasks, even those which do not need
-# to run. This makes it possible to investigate signature changes in post-build.sh.
-bitbake -S none ${_bitbake_targets}
-
 bitbake_build () {
   local targets="$@"
   if [ ! -z ${JOB_NAME+x} ]; then


### PR DESCRIPTION
We no longer have unexpected rebuilds, so we can remove the debug code
that was added for debugging those rebuilds. Makes the build a bit
faster again.
