### PR TITLE
[doc only] README: delete misspelled hyperlink tag

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -89,8 +89,6 @@ Specify one or more target image(s)::
 
 $ docker/local-build.sh refkit-image-common
 
-.. building witout docker:
-
 Building without Docker
 =======================
 


### PR DESCRIPTION
[skip-ci]

This tag is misspelled so it does not work.
Linking to this chapter works nevertheless, because
of implicit links to chapter headings.

(If we want to have explicit link as was original intention,
we can put this line back in corrected form)