### PR TITLE
CI : update exclude set, publish and test multiple configs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -134,9 +134,9 @@ try {
     test_targets = testinfo_data.split("\n")
     for(int i = 0; i < test_targets.size() && test_targets[i] != ""; i++) {
         def one_target_testinfo = test_targets[i]
-        def test_device = one_target_testinfo.split(',')[4]
-        def test_machine = one_target_testinfo.split(',')[3]
-        def img = one_target_testinfo.split(",")[0]
+        def test_device = one_target_testinfo.split(',')[5]
+        def test_machine = one_target_testinfo.split(',')[4]
+        def img = one_target_testinfo.split(",")[1]
         test_runs["test_${i}_${test_device}"] = {
             node('refkit-tester') {
                 deleteDir() // clean workspace

--- a/docker/publish-project.sh
+++ b/docker/publish-project.sh
@@ -135,12 +135,13 @@ fi
 ln -vsf ${CI_BUILD_ID} latest
 rsync -lv latest ${_RSYNC_DEST}/../
 
+# create clean tarball of source, leaving out .git* and parts created by build and test stages
 cd $WORKSPACE
 _tar_file=`mktemp --suffix=.tar.gz`
 tar czf ${_tar_file} . \
         --transform "s,^\.,${JOB_NAME}-${CI_BUILD_ID},S" \
-        --exclude 'bitbake*.log*' --exclude 'build' \
-        --exclude 'buildhistory' --exclude 'refkit_ci*' \
-        --exclude '.git' --exclude '*.testinfo.csv'
+        --exclude 'bitbake*.log*' --exclude 'build' --exclude 'build.pre' \
+        --exclude 'buildhistory*' --exclude 'refkit_ci*' \
+        --exclude '.git*' --exclude '*.testinfo.csv'
 rsync -av --chmod=F644 ${_tar_file} ${_RSYNC_DEST}/${JOB_NAME}-${CI_BUILD_ID}.tar.gz
 rm -f ${_tar_file}

--- a/docker/tester-exec.sh
+++ b/docker/tester-exec.sh
@@ -17,7 +17,7 @@
 
 # function to test an image with QEMU, call point in testimg() function
 test_qemu() {
-  wget ${_WGET_OPTS} ${CI_BUILD_URL}/images/${MACHINE}/ovmf.qcow2
+  wget ${_WGET_OPTS} ${CI_BUILD_URL}/glibc/images/${MACHINE}/ovmf.qcow2
 
   # Make port numbers and mac address that won't collide with anything
   PID=$$
@@ -62,9 +62,10 @@ test_qemu() {
 # function to test one image, see call point below.
 testimg() {
   declare -i num_masked=0
-  _IMG_NAME=$1
-  TEST_SUITE_FILE=$2
-  TEST_CASES_FILE=$3
+  _DEPL_PATH=$1
+  _IMG_NAME=$2
+  TEST_SUITE_FILE=$3
+  TEST_CASES_FILE=$4
 
   # Get test suite
   wget ${_WGET_OPTS} ${TEST_SUITE_FOLDER_URL}/${_IMG_NAME}/${TEST_SUITE_FILE}
@@ -74,8 +75,8 @@ testimg() {
 
   FILENAME=${_IMG_NAME}-${MACHINE}-${CI_BUILD_ID}.wic
   set +e
-  wget ${_WGET_OPTS} ${CI_BUILD_URL}/images/${MACHINE}/${FILENAME}.bmap
-  wget ${_WGET_OPTS} ${CI_BUILD_URL}/images/${MACHINE}/${FILENAME}.xz -O - | unxz - > ${FILENAME}
+  wget ${_WGET_OPTS} ${CI_BUILD_URL}/${_DEPL_PATH}/images/${MACHINE}/${FILENAME}.bmap
+  wget ${_WGET_OPTS} ${CI_BUILD_URL}/${_DEPL_PATH}/images/${MACHINE}/${FILENAME}.xz -O - | unxz - > ${FILENAME}
   if [ ! -s ${FILENAME} ]; then
       echo "ERROR: No file ${FILENAME}.xz, can not continue."
       exit 1
@@ -138,11 +139,11 @@ env |sort
 
 _WGET_OPTS="--no-verbose --no-proxy"
 CI_BUILD_URL=${COORD_BASE_URL}/builds/${JOB_NAME}/${CI_BUILD_ID}
-TEST_SUITE_FOLDER_URL=${CI_BUILD_URL}/testsuite/${MACHINE}
+TEST_SUITE_FOLDER_URL=${CI_BUILD_URL}/glibc/testsuite/${MACHINE}
 
 # get necessary params from testinfo.csv file written to tester workspace
 # by code in Jenkinsfile. We have just one line for this tester session.
-while IFS=, read _img _tsuite _tdata _mach _dev
+while IFS=, read _depl _img _tsuite _tdata _mach _dev
 do
-  [ "${_mach}" = "${MACHINE}" ] && testimg ${_img} ${_tsuite} ${_tdata}
+  [ "${_mach}" = "${MACHINE}" ] && testimg ${_depl} ${_img} ${_tsuite} ${_tdata}
 done < testinfo.csv

--- a/meta-refkit/conf/distro/include/refkit-ci.inc
+++ b/meta-refkit/conf/distro/include/refkit-ci.inc
@@ -92,17 +92,17 @@ REFKIT_CI_TEST_EXPORT_TARGETS="refkit-image-common refkit-image-computervision r
 # Execute automatic tests for following images with corresponding
 # test suite, test files and devices.
 # Space separated list of tuples, each should in format:
-# <image_name>,<testsuite_name>,<testfiles_name>,$MACHINE,<test_device_name>
+# <deploy_path>,<image_name>,<testsuite_name>,<testfiles_name>,$MACHINE,<test_device_name>
 REFKIT_CI_TEST_RUNS=" \
-  refkit-image-common,iot-testsuite.tar.gz,iot-testfiles.${MACHINE}.tar.gz,${MACHINE},570x \
-  refkit-image-common,iot-testsuite.tar.gz,iot-testfiles.${MACHINE}.tar.gz,${MACHINE},minnowboardturbot \
-  refkit-image-common,iot-testsuite.tar.gz,iot-testfiles.${MACHINE}.tar.gz,${MACHINE},qemu \
-  refkit-image-computervision,iot-testsuite.tar.gz,iot-testfiles.${MACHINE}.tar.gz,${MACHINE},570x \
-  refkit-image-computervision,iot-testsuite.tar.gz,iot-testfiles.${MACHINE}.tar.gz,${MACHINE},minnowboardturbot \
-  refkit-image-gateway,iot-testsuite.tar.gz,iot-testfiles.${MACHINE}.tar.gz,${MACHINE},570x \
-  refkit-image-gateway,iot-testsuite.tar.gz,iot-testfiles.${MACHINE}.tar.gz,${MACHINE},minnowboardturbot \
-  refkit-image-industrial,iot-testsuite.tar.gz,iot-testfiles.${MACHINE}.tar.gz,${MACHINE},570x \
-  refkit-image-industrial,iot-testsuite.tar.gz,iot-testfiles.${MACHINE}.tar.gz,${MACHINE},minnowboardturbot \
+  glibc,refkit-image-common,iot-testsuite.tar.gz,iot-testfiles.${MACHINE}.tar.gz,${MACHINE},570x \
+  glibc,refkit-image-common,iot-testsuite.tar.gz,iot-testfiles.${MACHINE}.tar.gz,${MACHINE},minnowboardturbot \
+  glibc,refkit-image-common,iot-testsuite.tar.gz,iot-testfiles.${MACHINE}.tar.gz,${MACHINE},qemu \
+  glibc,refkit-image-computervision,iot-testsuite.tar.gz,iot-testfiles.${MACHINE}.tar.gz,${MACHINE},570x \
+  glibc,refkit-image-computervision,iot-testsuite.tar.gz,iot-testfiles.${MACHINE}.tar.gz,${MACHINE},minnowboardturbot \
+  glibc,refkit-image-gateway,iot-testsuite.tar.gz,iot-testfiles.${MACHINE}.tar.gz,${MACHINE},570x \
+  glibc,refkit-image-gateway,iot-testsuite.tar.gz,iot-testfiles.${MACHINE}.tar.gz,${MACHINE},minnowboardturbot \
+  glibc,refkit-image-industrial,iot-testsuite.tar.gz,iot-testfiles.${MACHINE}.tar.gz,${MACHINE},570x \
+  glibc,refkit-image-industrial,iot-testsuite.tar.gz,iot-testfiles.${MACHINE}.tar.gz,${MACHINE},minnowboardturbot \
 "
 
 # Dont use disk space monitor in CI builds, to avoid frequent


### PR DESCRIPTION
commit 1: update exclude set of tarball creation
Changes in build and test setup have caused leaking some extras
in source tarball which don't belong there,
like build.pre, buildhistory-*,
making tarball size 27MB instead of 12MB.

commit 2: publish multiple config results

commit 3: CI tester: added deploy path to tester params
