### PR TITLE
Convolutional network component upgrades.

### DIFF
--- a/meta-refkit-extra/doc/computervision.rst
+++ b/meta-refkit-extra/doc/computervision.rst
@@ -68,3 +68,13 @@ have a web camera connected. Point the web camera at things and in the
 console you will see what the image classifier considers them to be. The
 deep neural network which the example uses is Caffenet, which is trained
 using the 1.3 million image ImageNet training set.
+
+Note that Caffe Python bindings are currently incompatible with OpenCV
+Python bindings, meaning that you can't use both ``cv2`` and ``caffe``
+at the same time in a Python application. The reason is a Protobuf
+conflict due to OpenCV DNN module. A workaround to the problem is to
+disable OpenCV DNN support by adding this to the ``local.conf`` file:
+
+.. code::
+
+    PACKAGECONFIG_remove_pn-opencv = "dnn"

--- a/meta-refkit-extra/recipes-convnet/caffe/caffe_git.bb
+++ b/meta-refkit-extra/recipes-convnet/caffe/caffe_git.bb
@@ -2,7 +2,7 @@ DESCRIPTION = "Build Caffe library for CNN using OpenBLAS lib"
 AUTHOR = "Alexander Leiva <norxander@gmail.com>"
 SUMMARY = "Caffe : A fast open framework for deep learning"
 HOMEPAGE = "http://caffe.berkeleyvision.org/"
-LICENSE = "BSD & BVLC-model-license"
+LICENSE = "BSD"
 PRIORITY= "optional"
 SECTION = "libs"
 PR = "r0"
@@ -29,22 +29,22 @@ DEPENDS = " \
 inherit python3native
 
 RDEPENDS_${PN} = "python3-numpy python3-imageio python3-six python3-protobuf"
+RDEPENDS_${PN}-imagenet-model = "caffe-bvlc-reference"
 
 LIC_FILES_CHKSUM = "file://LICENSE;md5=91d560803ea3d191c457b12834553991"
 
 SRC_URI = " \
     git://github.com/BVLC/caffe.git;branch=opencl \
-    http://dl.caffe.berkeleyvision.org/caffe_ilsvrc12.tar.gz;name=ilsvrc12 \
-    http://dl.caffe.berkeleyvision.org/bvlc_reference_caffenet.caffemodel;name=caffenet \
     file://0001-Allow-setting-numpy-include-dir-from-outside.patch \
     file://0002-cmake-do-not-use-SYSTEM-for-non-system-include-direc.patch \
     file://0003-cmake-fix-RPATHS.patch \
     file://0004-config-use-Python-3.patch \
     file://0005-io-change-to-imageio.patch \
     file://0006-classify-demo-added-a-demo-app-for-classifying-image.patch \
+    file://0007-net_gen.py-fix-Python-3-compatibility.patch \
     file://0001-cmake-find-Yocto-boost-python-libs.patch \
 "
-SRCREV = "f3ba72c520165d7c403a82770370f20472685d63"
+SRCREV = "73221fd37a5499f809796fac2ea95daba1a8ce02"
 
 SRC_URI[ilsvrc12.md5sum] = "f963098ea0e785a968ca1eb634003a90"
 SRC_URI[ilsvrc12.sha256sum] = "e35c0c1994a21f7d8ed49d01881ce17ab766743d3b0372cdc0183ff4d0dfc491"
@@ -59,19 +59,13 @@ PACKAGES += "${PN}-imagenet-model"
 RDEPENDS_${PN}-imagenet-model = "${PN}"
 
 do_install_append() {
+    # we need the BVLC ImageNet prototxt files for training & classification
     install -d ${D}${datadir}/Caffe/models/bvlc_reference_caffenet/
-    install -d ${D}${datadir}/Caffe/data/ilsvrc12
-
     install ${S}/models/bvlc_reference_caffenet/* ${D}${datadir}/Caffe/models/bvlc_reference_caffenet/
-    install ${WORKDIR}/synset_words.txt ${D}${datadir}/Caffe/data/ilsvrc12
-    install ${WORKDIR}/bvlc_reference_caffenet.caffemodel ${D}${datadir}/Caffe/models/bvlc_reference_caffenet/
-
-    # ilsvrc_2012_mean.npy is already installed at /usr/python/caffe/imagenet/ilsvrc_2012_mean.npy
 }
 
 FILES_${PN}-imagenet-model += " \
     ${datadir}/Caffe/models/bvlc_reference_caffenet/* \
-    ${datadir}/Caffe/data/ilsvrc12/* \
 "
 FILES_${PN} += " \
     ${prefix}/python/* \

--- a/meta-refkit-extra/recipes-convnet/caffe/files/0001-Allow-setting-numpy-include-dir-from-outside.patch
+++ b/meta-refkit-extra/recipes-convnet/caffe/files/0001-Allow-setting-numpy-include-dir-from-outside.patch
@@ -1,14 +1,14 @@
-From 3a0407e127559d2349f0217c6c5cf7751dd1aeba Mon Sep 17 00:00:00 2001
+From 80643c4aa7951e8b99a77f17fbebf346060dbad1 Mon Sep 17 00:00:00 2001
 From: Ismo Puustinen <ismo.puustinen@intel.com>
 Date: Tue, 25 Oct 2016 12:09:19 +0300
-Subject: [PATCH 1/6] Allow setting numpy include dir from outside.
+Subject: [PATCH 1/7] Allow setting numpy include dir from outside.
 
 ---
  cmake/Modules/FindNumPy.cmake | 16 ++++++++++------
  1 file changed, 10 insertions(+), 6 deletions(-)
 
 diff --git a/cmake/Modules/FindNumPy.cmake b/cmake/Modules/FindNumPy.cmake
-index a671494..38ebb32 100644
+index a671494c..38ebb328 100644
 --- a/cmake/Modules/FindNumPy.cmake
 +++ b/cmake/Modules/FindNumPy.cmake
 @@ -16,11 +16,16 @@ unset(NUMPY_VERSION)
@@ -39,5 +39,5 @@ index a671494..38ebb32 100644
  caffe_clear_vars(__result __output __error_value __values __ver_check __error_value)
 -
 -- 
-2.9.3
+2.13.3
 

--- a/meta-refkit-extra/recipes-convnet/caffe/files/0002-cmake-do-not-use-SYSTEM-for-non-system-include-direc.patch
+++ b/meta-refkit-extra/recipes-convnet/caffe/files/0002-cmake-do-not-use-SYSTEM-for-non-system-include-direc.patch
@@ -1,29 +1,19 @@
-From 9e698ecf0b354a87ea0bf79ee42a4e6ec09c7669 Mon Sep 17 00:00:00 2001
+From 7c89a5ba87b656e4884425683da73184c886ffd5 Mon Sep 17 00:00:00 2001
 From: Ismo Puustinen <ismo.puustinen@intel.com>
 Date: Fri, 17 Feb 2017 14:43:21 +0200
-Subject: [PATCH 2/6] cmake: do not use SYSTEM for non-system include
+Subject: [PATCH 2/7] cmake: do not use SYSTEM for non-system include
  directories.
 
 Signed-off-by: Ismo Puustinen <ismo.puustinen@intel.com>
 ---
- cmake/Dependencies.cmake | 8 ++++----
- cmake/ProtoBuf.cmake     | 2 +-
- 2 files changed, 5 insertions(+), 5 deletions(-)
+ cmake/Dependencies.cmake | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/cmake/Dependencies.cmake b/cmake/Dependencies.cmake
-index 00de565..0b861af 100644
+index 45bd93b0..0279769f 100644
 --- a/cmake/Dependencies.cmake
 +++ b/cmake/Dependencies.cmake
-@@ -6,7 +6,7 @@ set(Caffe_COMPILE_OPTIONS "")
- 
- # ---[ Boost
- find_package(Boost 1.46 REQUIRED COMPONENTS system thread filesystem)
--include_directories(SYSTEM PUBLIC ${Boost_INCLUDE_DIR})
-+include_directories(PUBLIC ${Boost_INCLUDE_DIR})
- add_definitions(-DBOOST_ALL_NO_LIB)
- list(APPEND Caffe_INCLUDE_DIRS PUBLIC ${Boost_INCLUDE_DIRS})
- list(APPEND Caffe_LINKER_LIBS PUBLIC ${Boost_LIBRARIES})
-@@ -66,14 +66,14 @@ else()
+@@ -62,14 +62,14 @@ else()
    endif()
  endif()
  
@@ -40,7 +30,7 @@ index 00de565..0b861af 100644
    list(APPEND Caffe_INCLUDE_DIRS PUBLIC ${HDF5_INCLUDE_DIRS})
    list(APPEND Caffe_LINKER_LIBS PUBLIC ${HDF5_LIBRARIES} ${HDF5_HL_LIBRARIES})
    add_definitions(-DUSE_HDF5)
-@@ -201,7 +201,7 @@ endif()
+@@ -197,7 +197,7 @@ endif()
  
  if(USE_NCCL)
    include("cmake/External/nccl.cmake")
@@ -49,19 +39,6 @@ index 00de565..0b861af 100644
    list(APPEND Caffe_LINKER_LIBS ${NCCL_LIBRARIES})
    add_definitions(-DUSE_NCCL)
  endif()
-diff --git a/cmake/ProtoBuf.cmake b/cmake/ProtoBuf.cmake
-index 2527195..dc6285b 100644
---- a/cmake/ProtoBuf.cmake
-+++ b/cmake/ProtoBuf.cmake
-@@ -8,7 +8,7 @@ if(MSVC)
- else()
-   find_package( Protobuf REQUIRED )
- endif()
--include_directories(SYSTEM ${PROTOBUF_INCLUDE_DIR})
-+include_directories(${PROTOBUF_INCLUDE_DIR})
- list(APPEND Caffe_INCLUDE_DIRS PUBLIC ${PROTOBUF_INCLUDE_DIR})
- list(APPEND Caffe_LINKER_LIBS PUBLIC ${PROTOBUF_LIBRARIES})
- 
 -- 
-2.9.3
+2.13.3
 

--- a/meta-refkit-extra/recipes-convnet/caffe/files/0003-cmake-fix-RPATHS.patch
+++ b/meta-refkit-extra/recipes-convnet/caffe/files/0003-cmake-fix-RPATHS.patch
@@ -1,7 +1,7 @@
-From 8d9b978681b7c7d5443f5503e2075b007fb460a5 Mon Sep 17 00:00:00 2001
+From 144b342bf280bc75cd0aa5b95c5256d87bba3afe Mon Sep 17 00:00:00 2001
 From: Ismo Puustinen <ismo.puustinen@intel.com>
 Date: Fri, 17 Feb 2017 15:35:43 +0200
-Subject: [PATCH 3/6] cmake: fix RPATHS.
+Subject: [PATCH 3/7] cmake: fix RPATHS.
 
 Signed-off-by: Ismo Puustinen <ismo.puustinen@intel.com>
 ---
@@ -9,7 +9,7 @@ Signed-off-by: Ismo Puustinen <ismo.puustinen@intel.com>
  1 file changed, 4 deletions(-)
 
 diff --git a/cmake/Misc.cmake b/cmake/Misc.cmake
-index 9dd2609..2150751 100644
+index 9dd2609b..2150751d 100644
 --- a/cmake/Misc.cmake
 +++ b/cmake/Misc.cmake
 @@ -28,10 +28,6 @@ if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
@@ -24,5 +24,5 @@ index 9dd2609..2150751 100644
  if(${__is_systtem_dir} STREQUAL -1)
    set(CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/lib)
 -- 
-2.9.3
+2.13.3
 

--- a/meta-refkit-extra/recipes-convnet/caffe/files/0004-config-use-Python-3.patch
+++ b/meta-refkit-extra/recipes-convnet/caffe/files/0004-config-use-Python-3.patch
@@ -1,7 +1,7 @@
-From a2e6ed1a11500896453c346c82713dd1869368b2 Mon Sep 17 00:00:00 2001
+From c623a37e4d0e52392dbdba371dc5de3f5ee915e6 Mon Sep 17 00:00:00 2001
 From: Ismo Puustinen <ismo.puustinen@intel.com>
 Date: Thu, 23 Feb 2017 18:01:09 +0200
-Subject: [PATCH 4/6] config: use Python 3.
+Subject: [PATCH 4/7] config: use Python 3.
 
 Upstream-status: Inappropriate
 
@@ -11,10 +11,10 @@ Signed-off-by: Ismo Puustinen <ismo.puustinen@intel.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index c6f9ca6..aceb1e8 100755
+index 7f272bc7..4585727f 100755
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -68,7 +68,7 @@ else()
+@@ -70,7 +70,7 @@ else()
    caffe_option(BUILD_SHARED_LIBS "Build shared libraries" ON)
  endif()
  caffe_option(BUILD_python "Build Python wrapper" ON)
@@ -24,5 +24,5 @@ index c6f9ca6..aceb1e8 100755
  caffe_option(BUILD_docs   "Build documentation" ON IF UNIX OR APPLE)
  caffe_option(BUILD_python_layer "Build the Caffe Python layer" ON)
 -- 
-2.9.3
+2.13.3
 

--- a/meta-refkit-extra/recipes-convnet/caffe/files/0005-io-change-to-imageio.patch
+++ b/meta-refkit-extra/recipes-convnet/caffe/files/0005-io-change-to-imageio.patch
@@ -1,7 +1,7 @@
-From b5a475cbabd67a7c31c01698f55814895f194730 Mon Sep 17 00:00:00 2001
+From 8e942864a426b49b1cda1693ea40ea8766c4e3e6 Mon Sep 17 00:00:00 2001
 From: Ismo Puustinen <ismo.puustinen@intel.com>
 Date: Fri, 24 Feb 2017 16:07:09 +0200
-Subject: [PATCH 5/6] io: change to imageio.
+Subject: [PATCH 5/7] io: change to imageio.
 
 This gets rid of the whole sciki-image dependency (and as a consequence,
 drops the matplotlib dependency). Note that some operations meant for
@@ -17,7 +17,7 @@ Signed-off-by: Ismo Puustinen <ismo.puustinen@intel.com>
  1 file changed, 11 insertions(+), 4 deletions(-)
 
 diff --git a/python/caffe/io.py b/python/caffe/io.py
-index e1759be..ebccca2 100644
+index 966c164c..83b87837 100644
 --- a/python/caffe/io.py
 +++ b/python/caffe/io.py
 @@ -1,7 +1,5 @@
@@ -70,5 +70,5 @@ index e1759be..ebccca2 100644
          scale = tuple(np.array(new_dims, dtype=float) / np.array(im.shape[:2]))
          resized_im = zoom(im, scale + (1,), order=interp_order)
 -- 
-2.9.3
+2.13.3
 

--- a/meta-refkit-extra/recipes-convnet/caffe/files/0006-classify-demo-added-a-demo-app-for-classifying-image.patch
+++ b/meta-refkit-extra/recipes-convnet/caffe/files/0006-classify-demo-added-a-demo-app-for-classifying-image.patch
@@ -1,7 +1,7 @@
-From dc4f9ab92cbcb5b0224ce81d00c91824c0df89fd Mon Sep 17 00:00:00 2001
+From d8a1015699c7c5600f1cc9f1e60cb4911cc17973 Mon Sep 17 00:00:00 2001
 From: Ismo Puustinen <ismo.puustinen@intel.com>
 Date: Tue, 28 Feb 2017 16:38:26 +0200
-Subject: [PATCH 6/6] classify-demo: added a demo app for classifying images.
+Subject: [PATCH 6/7] classify-demo: added a demo app for classifying images.
 
 This is a modification of the existing classify.py script in the same
 folder. The modified script is meant to be suitable for interactive use,
@@ -19,7 +19,7 @@ Signed-off-by: Ismo Puustinen <ismo.puustinen@intel.com>
 
 diff --git a/python/classify-demo.py b/python/classify-demo.py
 new file mode 100755
-index 0000000..f411c98
+index 00000000..f411c98d
 --- /dev/null
 +++ b/python/classify-demo.py
 @@ -0,0 +1,167 @@
@@ -191,5 +191,5 @@ index 0000000..f411c98
 +if __name__ == '__main__':
 +    main(sys.argv)
 -- 
-2.9.3
+2.13.3
 

--- a/meta-refkit-extra/recipes-convnet/caffe/files/0007-net_gen.py-fix-Python-3-compatibility.patch
+++ b/meta-refkit-extra/recipes-convnet/caffe/files/0007-net_gen.py-fix-Python-3-compatibility.patch
@@ -1,0 +1,39 @@
+From 97a7af88c2f9653a74b6ad489f566c9db460178f Mon Sep 17 00:00:00 2001
+From: Ismo Puustinen <ismo.puustinen@intel.com>
+Date: Wed, 14 Jun 2017 15:14:24 +0300
+Subject: [PATCH 7/7] net_gen.py: fix Python 3 compatibility.
+
+Upstream-status: Inappropriate
+
+Signed-off-by: Ismo Puustinen <ismo.puustinen@intel.com>
+---
+ python/caffe/net_gen.py | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/python/caffe/net_gen.py b/python/caffe/net_gen.py
+index 287ae97f..9d8f5158 100755
+--- a/python/caffe/net_gen.py
++++ b/python/caffe/net_gen.py
+@@ -9,7 +9,7 @@ from collections import OrderedDict, Counter, Iterable
+ from caffe import layers as L, params as P, to_proto
+ from caffe.proto import caffe_pb2
+ import six
+-from compiler.ast import nodes
++# from compiler.ast import nodes
+ 
+ 
+ class MetaLayers(object):
+@@ -501,8 +501,8 @@ def fix_input_dims(net, source_layers, max_shapes=[], min_shapes=[], shape_coupl
+ 
+                 # Test the shape
+                 if (verbose or not error):
+-                    print test_current_shapes
+-                    print "Valid shape: " + str(not error)
++                    print(test_current_shapes)
++                    print("Valid shape: " + str(not error))
+                 
+                 if (error and ((len(test_current_shapes[curr_src_idx]) - 2 <= dim_idx) or (test_current_shapes[curr_src_idx][2 + dim_idx] == test_min_shapes[curr_src_idx][2 + dim_idx]))):
+                     # Reached minimum shape, reset source and go to previous source
+-- 
+2.13.3
+

--- a/meta-refkit-extra/recipes-convnet/hdf5/files/configuration.patch
+++ b/meta-refkit-extra/recipes-convnet/hdf5/files/configuration.patch
@@ -1,9 +1,9 @@
 diff --git a/H5Tinit.c b/H5Tinit.c
 new file mode 100644
-index 0000000..ef1afc4
+index 0000000..3464959
 --- /dev/null
 +++ b/H5Tinit.c
-@@ -0,0 +1,977 @@
+@@ -0,0 +1,991 @@
 +/* Generated automatically by H5detect -- do not edit */
 +
 +
@@ -15,16 +15,14 @@ index 0000000..ef1afc4
 + *                                                                           *
 + * This file is part of HDF5.  The full HDF5 copyright notice, including     *
 + * terms governing use, modification, and redistribution, is contained in    *
-+ * the files COPYING and Copyright.html.  COPYING can be found at the root   *
-+ * of the source code distribution tree; Copyright.html can be found at the  *
-+ * root level of an installed copy of the electronic HDF5 document set and   *
-+ * is linked from the top-level documents page.  It can also be found at     *
-+ * http://hdfgroup.org/HDF5/doc/Copyright.html.  If you do not have          *
-+ * access to either file, you may request a copy from help@hdfgroup.org.     *
++ * the COPYING file, which can be found at the root of the source code       *
++ * distribution tree, or in https://support.hdfgroup.org/ftp/HDF5/releases.  *
++ * If you do not have access to either file, you may request a copy from     *
++ * help@hdfgroup.org.                                                        *
 + * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 + *
-+ * Created:		Nov 30, 2015
-+ *			root <root@cyclone5>
++ * Created:		Jul 31, 2017
++ *			root <root@intel-corei7-64>
 + *
 + * Purpose:		This machine-generated source code contains
 + *			information about the various integer and
@@ -276,6 +274,8 @@ index 0000000..ef1afc4
 +    H5T_NATIVE_UINT_ALIGN_g = 1;
 +
 +   /*
++    *    7        6        5        4
++    * IIIIIIII IIIIIIII IIIIIIII IIIIIIII
 +    *    3        2        1        0
 +    * IIIIIIII IIIIIIII IIIIIIII IIIIIIII
 +    * Alignment: none
@@ -284,19 +284,21 @@ index 0000000..ef1afc4
 +        HGOTO_ERROR(H5E_DATATYPE, H5E_NOSPACE, FAIL, "datatype allocation failed")
 +    dt->shared->state = H5T_STATE_IMMUTABLE;
 +    dt->shared->type = H5T_INTEGER;
-+    dt->shared->size = 4;
++    dt->shared->size = 8;
 +    dt->shared->u.atomic.order = H5T_ORDER_LE;
 +    dt->shared->u.atomic.offset = 0;
-+    dt->shared->u.atomic.prec = 32;
++    dt->shared->u.atomic.prec = 64;
 +    dt->shared->u.atomic.lsb_pad = H5T_PAD_ZERO;
 +    dt->shared->u.atomic.msb_pad = H5T_PAD_ZERO;
 +    dt->shared->u.atomic.u.i.sign = H5T_SGN_2;
 +    if((H5T_NATIVE_LONG_g = H5I_register(H5I_DATATYPE, dt, FALSE)) < 0)
 +        HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, FAIL, "can't register ID for built-in datatype")
 +    H5T_NATIVE_LONG_ALIGN_g = 1;
-+    H5T_NATIVE_LONG_COMP_ALIGN_g = 4;
++    H5T_NATIVE_LONG_COMP_ALIGN_g = 8;
 +
 +   /*
++    *    7        6        5        4
++    * UUUUUUUU UUUUUUUU UUUUUUUU UUUUUUUU
 +    *    3        2        1        0
 +    * UUUUUUUU UUUUUUUU UUUUUUUU UUUUUUUU
 +    * Alignment: none
@@ -305,10 +307,10 @@ index 0000000..ef1afc4
 +        HGOTO_ERROR(H5E_DATATYPE, H5E_NOSPACE, FAIL, "datatype allocation failed")
 +    dt->shared->state = H5T_STATE_IMMUTABLE;
 +    dt->shared->type = H5T_INTEGER;
-+    dt->shared->size = 4;
++    dt->shared->size = 8;
 +    dt->shared->u.atomic.order = H5T_ORDER_LE;
 +    dt->shared->u.atomic.offset = 0;
-+    dt->shared->u.atomic.prec = 32;
++    dt->shared->u.atomic.prec = 64;
 +    dt->shared->u.atomic.lsb_pad = H5T_PAD_ZERO;
 +    dt->shared->u.atomic.msb_pad = H5T_PAD_ZERO;
 +    dt->shared->u.atomic.u.i.sign = H5T_SGN_NONE;
@@ -517,6 +519,8 @@ index 0000000..ef1afc4
 +    H5T_NATIVE_UINT_LEAST16_ALIGN_g = 1;
 +
 +   /*
++    *    7        6        5        4
++    * IIIIIIII IIIIIIII IIIIIIII IIIIIIII
 +    *    3        2        1        0
 +    * IIIIIIII IIIIIIII IIIIIIII IIIIIIII
 +    * Alignment: none
@@ -525,10 +529,10 @@ index 0000000..ef1afc4
 +        HGOTO_ERROR(H5E_DATATYPE, H5E_NOSPACE, FAIL, "datatype allocation failed")
 +    dt->shared->state = H5T_STATE_IMMUTABLE;
 +    dt->shared->type = H5T_INTEGER;
-+    dt->shared->size = 4;
++    dt->shared->size = 8;
 +    dt->shared->u.atomic.order = H5T_ORDER_LE;
 +    dt->shared->u.atomic.offset = 0;
-+    dt->shared->u.atomic.prec = 32;
++    dt->shared->u.atomic.prec = 64;
 +    dt->shared->u.atomic.lsb_pad = H5T_PAD_ZERO;
 +    dt->shared->u.atomic.msb_pad = H5T_PAD_ZERO;
 +    dt->shared->u.atomic.u.i.sign = H5T_SGN_2;
@@ -537,6 +541,8 @@ index 0000000..ef1afc4
 +    H5T_NATIVE_INT_FAST16_ALIGN_g = 1;
 +
 +   /*
++    *    7        6        5        4
++    * UUUUUUUU UUUUUUUU UUUUUUUU UUUUUUUU
 +    *    3        2        1        0
 +    * UUUUUUUU UUUUUUUU UUUUUUUU UUUUUUUU
 +    * Alignment: none
@@ -545,10 +551,10 @@ index 0000000..ef1afc4
 +        HGOTO_ERROR(H5E_DATATYPE, H5E_NOSPACE, FAIL, "datatype allocation failed")
 +    dt->shared->state = H5T_STATE_IMMUTABLE;
 +    dt->shared->type = H5T_INTEGER;
-+    dt->shared->size = 4;
++    dt->shared->size = 8;
 +    dt->shared->u.atomic.order = H5T_ORDER_LE;
 +    dt->shared->u.atomic.offset = 0;
-+    dt->shared->u.atomic.prec = 32;
++    dt->shared->u.atomic.prec = 64;
 +    dt->shared->u.atomic.lsb_pad = H5T_PAD_ZERO;
 +    dt->shared->u.atomic.msb_pad = H5T_PAD_ZERO;
 +    dt->shared->u.atomic.u.i.sign = H5T_SGN_NONE;
@@ -637,6 +643,8 @@ index 0000000..ef1afc4
 +    H5T_NATIVE_UINT_LEAST32_ALIGN_g = 1;
 +
 +   /*
++    *    7        6        5        4
++    * IIIIIIII IIIIIIII IIIIIIII IIIIIIII
 +    *    3        2        1        0
 +    * IIIIIIII IIIIIIII IIIIIIII IIIIIIII
 +    * Alignment: none
@@ -645,10 +653,10 @@ index 0000000..ef1afc4
 +        HGOTO_ERROR(H5E_DATATYPE, H5E_NOSPACE, FAIL, "datatype allocation failed")
 +    dt->shared->state = H5T_STATE_IMMUTABLE;
 +    dt->shared->type = H5T_INTEGER;
-+    dt->shared->size = 4;
++    dt->shared->size = 8;
 +    dt->shared->u.atomic.order = H5T_ORDER_LE;
 +    dt->shared->u.atomic.offset = 0;
-+    dt->shared->u.atomic.prec = 32;
++    dt->shared->u.atomic.prec = 64;
 +    dt->shared->u.atomic.lsb_pad = H5T_PAD_ZERO;
 +    dt->shared->u.atomic.msb_pad = H5T_PAD_ZERO;
 +    dt->shared->u.atomic.u.i.sign = H5T_SGN_2;
@@ -657,6 +665,8 @@ index 0000000..ef1afc4
 +    H5T_NATIVE_INT_FAST32_ALIGN_g = 1;
 +
 +   /*
++    *    7        6        5        4
++    * UUUUUUUU UUUUUUUU UUUUUUUU UUUUUUUU
 +    *    3        2        1        0
 +    * UUUUUUUU UUUUUUUU UUUUUUUU UUUUUUUU
 +    * Alignment: none
@@ -665,10 +675,10 @@ index 0000000..ef1afc4
 +        HGOTO_ERROR(H5E_DATATYPE, H5E_NOSPACE, FAIL, "datatype allocation failed")
 +    dt->shared->state = H5T_STATE_IMMUTABLE;
 +    dt->shared->type = H5T_INTEGER;
-+    dt->shared->size = 4;
++    dt->shared->size = 8;
 +    dt->shared->u.atomic.order = H5T_ORDER_LE;
 +    dt->shared->u.atomic.offset = 0;
-+    dt->shared->u.atomic.prec = 32;
++    dt->shared->u.atomic.prec = 64;
 +    dt->shared->u.atomic.lsb_pad = H5T_PAD_ZERO;
 +    dt->shared->u.atomic.msb_pad = H5T_PAD_ZERO;
 +    dt->shared->u.atomic.u.i.sign = H5T_SGN_NONE;
@@ -914,42 +924,46 @@ index 0000000..ef1afc4
 +    H5T_NATIVE_DOUBLE_COMP_ALIGN_g = 8;
 +
 +   /*
++    *   15       14       13       12
++    * ???????? ???????? ???????? ????????
++    *   11       10        9        8
++    * ???????? ???????? SEEEEEEE EEEEEEEE
 +    *    7        6        5        4
-+    * SEEEEEEE EEEEMMMM MMMMMMMM MMMMMMMM
++    * MMMMMMMM MMMMMMMM MMMMMMMM MMMMMMMM
 +    *    3        2        1        0
 +    * MMMMMMMM MMMMMMMM MMMMMMMM MMMMMMMM
-+    * Implicit bit? yes
++    * Implicit bit? no
 +    * Alignment: none
 +    */
 +    if(NULL == (dt = H5T__alloc()))
 +        HGOTO_ERROR(H5E_DATATYPE, H5E_NOSPACE, FAIL, "datatype allocation failed")
 +    dt->shared->state = H5T_STATE_IMMUTABLE;
 +    dt->shared->type = H5T_FLOAT;
-+    dt->shared->size = 8;
++    dt->shared->size = 16;
 +    dt->shared->u.atomic.order = H5T_ORDER_LE;
 +    dt->shared->u.atomic.offset = 0;
-+    dt->shared->u.atomic.prec = 64;
++    dt->shared->u.atomic.prec = 80;
 +    dt->shared->u.atomic.lsb_pad = H5T_PAD_ZERO;
 +    dt->shared->u.atomic.msb_pad = H5T_PAD_ZERO;
-+    dt->shared->u.atomic.u.f.sign = 63;
-+    dt->shared->u.atomic.u.f.epos = 52;
-+    dt->shared->u.atomic.u.f.esize = 11;
-+    dt->shared->u.atomic.u.f.ebias = 0x000003ff;
++    dt->shared->u.atomic.u.f.sign = 79;
++    dt->shared->u.atomic.u.f.epos = 64;
++    dt->shared->u.atomic.u.f.esize = 15;
++    dt->shared->u.atomic.u.f.ebias = 0x00003fff;
 +    dt->shared->u.atomic.u.f.mpos = 0;
-+    dt->shared->u.atomic.u.f.msize = 52;
-+    dt->shared->u.atomic.u.f.norm = H5T_NORM_IMPLIED;
++    dt->shared->u.atomic.u.f.msize = 64;
++    dt->shared->u.atomic.u.f.norm = H5T_NORM_NONE;
 +    dt->shared->u.atomic.u.f.pad = H5T_PAD_ZERO;
 +    if((H5T_NATIVE_LDOUBLE_g = H5I_register(H5I_DATATYPE, dt, FALSE)) < 0)
 +        HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, FAIL, "can't register ID for built-in datatype")
 +    H5T_NATIVE_LDOUBLE_ALIGN_g = 1;
-+    H5T_NATIVE_LDOUBLE_COMP_ALIGN_g = 8;
++    H5T_NATIVE_LDOUBLE_COMP_ALIGN_g = 16;
 +
 +    /* Set the native order for this machine */
 +    H5T_native_order_g = H5T_ORDER_LE;
 +
 +    /* Structure alignment for pointers, hvl_t, hobj_ref_t, hdset_reg_ref_t */
-+    H5T_POINTER_COMP_ALIGN_g = 4;
-+    H5T_HVL_COMP_ALIGN_g = 4;
++    H5T_POINTER_COMP_ALIGN_g = 8;
++    H5T_HVL_COMP_ALIGN_g = 8;
 +    H5T_HOBJREF_COMP_ALIGN_g = 8;
 +    H5T_HDSETREGREF_COMP_ALIGN_g = 1;
 +
@@ -983,10 +997,10 @@ index 0000000..ef1afc4
 +/* sigill_handler called: 5 times */
 diff --git a/H5lib_settings.c b/H5lib_settings.c
 new file mode 100644
-index 0000000..0af36e0
+index 0000000..c362605
 --- /dev/null
 +++ b/H5lib_settings.c
-@@ -0,0 +1,101 @@
+@@ -0,0 +1,105 @@
 +/* Generated automatically by H5make_libsettings -- do not edit */
 +
 +
@@ -998,16 +1012,14 @@ index 0000000..0af36e0
 + *                                                                           *
 + * This file is part of HDF5.  The full HDF5 copyright notice, including     *
 + * terms governing use, modification, and redistribution, is contained in    *
-+ * the files COPYING and Copyright.html.  COPYING can be found at the root   *
-+ * of the source code distribution tree; Copyright.html can be found at the  *
-+ * root level of an installed copy of the electronic HDF5 document set and   *
-+ * is linked from the top-level documents page.  It can also be found at     *
-+ * http://hdfgroup.org/HDF5/doc/Copyright.html.  If you do not have          *
-+ * access to either file, you may request a copy from help@hdfgroup.org.     *
++ * the COPYING file, which can be found at the root of the source code       *
++ * distribution tree, or in https://support.hdfgroup.org/ftp/HDF5/releases.  *
++ * If you do not have access to either file, you may request a copy from     *
++ * help@hdfgroup.org.                                                        *
 + * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 + *
-+ * Created:		Nov 30, 2015
-+ *			root <root@cyclone5>
++ * Created:		Jul 31, 2017
++ *			root <root@intel-corei7-64>
 + *
 + * Purpose:		This machine-generated source code contains
 + *			information about the library build configuration
@@ -1021,70 +1033,76 @@ index 0000000..0af36e0
 + */
 +
 +char H5libhdf5_settings[]=
-+	"	    SUMMARY OF THE HDF5 CONFIGURATION\n"
-+	"	    =================================\n"
++	"      SUMMARY OF THE HDF5 CONFIGURATION                        \n"
++	"      =================================                        \n"
 +	"\n"
-+	"General Information:\n"
-+	"-------------------\n"
-+	"		   HDF5 Version: 1.8.16\n"
-+	"		  Configured on: Mon Nov 30 02:44:24 UTC 2015\n"
-+	"		  Configured by: norxander@debian\n"
-+	"		 Configure mode: production\n"
-+	"		    Host system: arm-poky-linux-gnueabi\n"
-+	"	      Uname information: Linux debian 3.16.0-4-amd64 #1 SMP Debian 3.16.7-ckt11-1+deb8u6 (2015-11-09) x86_64 GNU/Linux\n"
-+	"		       Byte sex: little-endian\n"
-+	"		      Libraries: static, shared\n"
-+	"	     Installation point: /media/dataLinux/Work/Git/build/tmp/work/cortexa9hf-vfp-neon-poky-linux-gnueabi/hdf5/1.8.16-r0/image/usr\n"
++	"General Information:           \n"
++	"-------------------            \n"
++	"                   HDF5 Version: 1.8.19                        \n"
++	"                  Configured on: 2017-08-01                    \n"
++	"                  Configured by: Unix Makefiles                \n"
++	"                 Configure mode: CMAKE 3.8.2                   \n"
++	"                    Host system: Linux-4.11.11-300.fc26.x86_64 \n"
++	"              Uname information: Linux                         \n"
++	"                       Byte sex: little-endian                 \n"
++	"                      Libraries:                               \n"
++	"             Installation point: /u/ssd/intel-iot-refkit/build/tmp-glibc/work/corei7-64-refkit-linux/hdf5/1.8.19-r0/image/usr \n"
 +	"\n"
-+	"Compiling Options:\n"
-+	"------------------\n"
-+	"               Compilation Mode: production\n"
-+	"                     C Compiler: /media/dataLinux/Work/Git/build/tmp/sysroots/x86_64-linux/usr/bin/arm-poky-linux-gnueabi/arm-poky-linux-gnueabi-gcc  -march=armv7-a -mfloat-abi=hard -mfpu=neon -mtune=cortex-a9 --sysroot=/media/dataLinux/Work/Git/build/tmp/sysroots/cyclone5\n"
-+	"                         CFLAGS:  -O2 -pipe -g -feliminate-unused-debug-types\n"
-+	"                      H5_CFLAGS:  \n"
-+	"                      AM_CFLAGS: \n"
-+	"                       CPPFLAGS: \n"
-+	"                    H5_CPPFLAGS: -D_GNU_SOURCE -D_POSIX_C_SOURCE=200112L   -DNDEBUG -UH5_DEBUG_API\n"
-+	"                    AM_CPPFLAGS: -D_LARGEFILE64_SOURCE -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64  -I/media/dataLinux/Work/Git/build/tmp/sysroots/cyclone5/usr/include\n"
-+	"               Shared C Library: yes\n"
-+	"               Static C Library: yes\n"
-+	"  Statically Linked Executables: no\n"
-+	"                        LDFLAGS: -Wl,-O1 -Wl,--hash-style=gnu -Wl,--as-needed\n"
-+	"                     H5_LDFLAGS: \n"
-+	"                     AM_LDFLAGS:  -L/media/dataLinux/Work/Git/build/tmp/sysroots/cyclone5/usr/lib\n"
-+	" 	 	Extra libraries: -lz -ldl -lm \n"
-+	" 		       Archiver: arm-poky-linux-gnueabi-ar\n"
-+	" 		 	 Ranlib: arm-poky-linux-gnueabi-ranlib\n"
-+	" 	      Debugged Packages: \n"
-+	"		    API Tracing: no\n"
++	"Compiling Options:             \n"
++	"------------------             \n"
++	"               Compilation Mode:                               \n"
++	"                     C Compiler: /u/ssd/intel-iot-refkit/build/tmp-glibc/work/corei7-64-refkit-linux/hdf5/1.8.19-r0/recipe-sysroot-native/usr/bin/x86_64-refkit-linux/x86_64-refkit-linux-gcc\n"
++	"                         CFLAGS:   -m64 -march=corei7 -mtune=corei7 -mfpmath=sse -msse4.2 -fstack-protector-strong  -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security  --sysroot=/u/ssd/intel-iot-refkit/build/tmp-glibc/work/corei7-64-refkit-linux/hdf5/1.8.19-r0/recipe-sysroot  -O2 -pipe -g -feliminate-unused-debug-types -fdebug-prefix-map=/u/ssd/intel-iot-refkit/build/tmp-glibc/work/corei7-64-refkit-linux/hdf5/1.8.19-r0=/usr/src/debug/hdf5/1.8.19-r0 -fdebug-prefix-map=/u/ssd/intel-iot-refkit/build/tmp-glibc/work/corei7-64-refkit-linux/hdf5/1.8.19-r0/recipe-sysroot-native= -fdebug-prefix-map=/u/ssd/intel-iot-refkit/build/tmp-glibc/work/corei7-64-refkit-linux/hdf5/1.8.19-r0/recipe-sysroot=   -m64 -march=corei7 -mtune=corei7 -mfpmath=sse -msse4.2 -fstack-protector-strong  -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security  --sysroot=/u/ssd/intel-iot-refkit/build/tmp-glibc/work/corei7-64-refkit-linux/hdf5/1.8.19-r0/recipe-sysroot -std=c99 -fstdarg-opt -Wundef -Wshadow -Wpointer-arith -Wbad-function-cast -Wcast-align -Wwrite-strings -Wconversion -Waggregate-return -Wstrict-prototypes -Wmissing-prototypes -Wmissing-declarations -Wredundant-decls -Wnested-externs -Wno-unused-parameter -Wno-inline -Wno-aggregate-return -fmessage-length=0\n"
++	"                      H5_CFLAGS:                               \n"
++	"                      AM_CFLAGS:                               \n"
++	"                       CPPFLAGS:                               \n"
++	"                    H5_CPPFLAGS:                               \n"
++	"                    AM_CPPFLAGS:                               \n"
++	"               Shared C Library: YES                           \n"
++	"               Static C Library: YES                           \n"
++	"  Statically Linked Executables: OFF                           \n"
++	"                        LDFLAGS: -Wl,-O1 -Wl,--hash-style=gnu -Wl,--as-needed -fstack-protector-strong -Wl,-z,relro,-z,now    \n"
++	"                     AM_LDFLAGS:                               \n"
++	"                Extra libraries: m;dl                          \n"
++	"                       Archiver: x86_64-refkit-linux-ar        \n"
++	"                         Ranlib: /u/ssd/intel-iot-refkit/build/tmp-glibc/work/corei7-64-refkit-linux/hdf5/1.8.19-r0/recipe-sysroot-native/usr/bin/x86_64-refkit-linux/x86_64-refkit-linux-ranlib\n"
++	"              Debugged Packages:                               \n"
++	"                    API Tracing: OFF                           \n"
 +	"\n"
-+	"Languages:\n"
-+	"----------\n"
-+	"                        Fortran: no\n"
++	"Languages:                     \n"
++	"----------                     \n"
++	"                        Fortran: OFF                           \n"
++	"               Fortran Compiler:                               \n"
++	"          Fortran 2003 Compiler:                               \n"
++	"                  Fortran Flags:                               \n"
++	"               H5 Fortran Flags:                               \n"
++	"               AM Fortran Flags:                               \n"
++	"         Shared Fortran Library: YES                           \n"
++	"         Static Fortran Library: YES                           \n"
 +	"\n"
-+	"                            C++: yes\n"
-+	"                   C++ Compiler: /media/dataLinux/Work/Git/build/tmp/sysroots/x86_64-linux/usr/bin/arm-poky-linux-gnueabi/arm-poky-linux-gnueabi-g++  -march=armv7-a -mfloat-abi=hard -mfpu=neon -mtune=cortex-a9 --sysroot=/media/dataLinux/Work/Git/build/tmp/sysroots/cyclone5\n"
-+	"                      C++ Flags:  -O2 -pipe -g -feliminate-unused-debug-types -fvisibility-inlines-hidden\n"
-+	"                   H5 C++ Flags:  \n"
-+	"                   AM C++ Flags: \n"
-+	"             Shared C++ Library: yes\n"
-+	"             Static C++ Library: yes\n"
++	"                            C++: ON                            \n"
++	"                   C++ Compiler: /u/ssd/intel-iot-refkit/build/tmp-glibc/work/corei7-64-refkit-linux/hdf5/1.8.19-r0/recipe-sysroot-native/usr/bin/x86_64-refkit-linux/x86_64-refkit-linux-g++\n"
++	"                      C++ Flags:   -m64 -march=corei7 -mtune=corei7 -mfpmath=sse -msse4.2 -fstack-protector-strong  -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security  --sysroot=/u/ssd/intel-iot-refkit/build/tmp-glibc/work/corei7-64-refkit-linux/hdf5/1.8.19-r0/recipe-sysroot  -O2 -pipe -g -feliminate-unused-debug-types -fdebug-prefix-map=/u/ssd/intel-iot-refkit/build/tmp-glibc/work/corei7-64-refkit-linux/hdf5/1.8.19-r0=/usr/src/debug/hdf5/1.8.19-r0 -fdebug-prefix-map=/u/ssd/intel-iot-refkit/build/tmp-glibc/work/corei7-64-refkit-linux/hdf5/1.8.19-r0/recipe-sysroot-native= -fdebug-prefix-map=/u/ssd/intel-iot-refkit/build/tmp-glibc/work/corei7-64-refkit-linux/hdf5/1.8.19-r0/recipe-sysroot=  -fvisibility-inlines-hidden  -m64 -march=corei7 -mtune=corei7 -mfpmath=sse -msse4.2 -fstack-protector-strong  -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security  --sysroot=/u/ssd/intel-iot-refkit/build/tmp-glibc/work/corei7-64-refkit-linux/hdf5/1.8.19-r0/recipe-sysroot -fstdarg-opt -fmessage-length=0\n"
++	"                   H5 C++ Flags:                               \n"
++	"                   AM C++ Flags:                               \n"
++	"             Shared C++ Library: YES                           \n"
++	"             Static C++ Library: YES                           \n"
 +	"\n"
-+	"Features:\n"
-+	"---------\n"
-+	"                  Parallel HDF5: no\n"
-+	"             High Level library: yes\n"
-+	"                   Threadsafety: no\n"
-+	"            Default API Mapping: v18\n"
-+	" With Deprecated Public Symbols: yes\n"
-+	"         I/O filters (external): deflate(zlib)\n"
-+	"                            MPE: no\n"
-+	"                     Direct VFD: no\n"
-+	"                        dmalloc: no\n"
-+	"Clear file buffers before write: yes\n"
-+	"           Using memory checker: no\n"
-+	"         Function Stack Tracing: no\n"
-+	"      Strict File Format Checks: no\n"
-+	"   Optimization Instrumentation: no\n"
++	"Features:                      \n"
++	"---------                      \n"
++	"                  Parallel HDF5: OFF                           \n"
++	"             High Level library: ON                            \n"
++	"                   Threadsafety: OFF                           \n"
++	"            Default API Mapping: v18                           \n"
++	" With Deprecated Public Symbols: ON                            \n"
++	"         I/O filters (external):                               \n"
++	"                            MPE:                               \n"
++	"                     Direct VFD:                               \n"
++	"                        dmalloc:                               \n"
++	"Clear file buffers before write: ON                            \n"
++	"           Using memory checker: OFF                           \n"
++	"         Function Stack Tracing: OFF                           \n"
++	"      Strict File Format Checks: OFF                           \n"
++	"   Optimization Instrumentation:   \n"
 +;
 +

--- a/meta-refkit-extra/recipes-convnet/hdf5/files/copy_generated.patch
+++ b/meta-refkit-extra/recipes-convnet/hdf5/files/copy_generated.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index fa3c971..f1ec7e2 100644
+index 08a65c4..9af14d5 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -797,4 +797,10 @@ endif (EXISTS "${HDF5_SOURCE_DIR}/c++" AND IS_DIRECTORY "${HDF5_SOURCE_DIR}/c++"
+@@ -817,4 +817,10 @@ endif ()
  #-----------------------------------------------------------------------------
  configure_file (${HDF_RESOURCES_DIR}/H5pubconf.h.in ${HDF5_BINARY_DIR}/H5pubconf.h @ONLY)
  

--- a/meta-refkit-extra/recipes-convnet/hdf5/files/generation.patch
+++ b/meta-refkit-extra/recipes-convnet/hdf5/files/generation.patch
@@ -1,8 +1,8 @@
 diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
-index 9fcb28d..b58bf18 100644
+index d343208..6b7ef1b 100644
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
-@@ -606,39 +606,6 @@ set (H5_PRIVATE_HEADERS
+@@ -607,39 +607,6 @@ set (H5_PRIVATE_HEADERS
      ${HDF5_SRC_DIR}/H5win32defs.h
  )
  
@@ -14,7 +14,7 @@ index 9fcb28d..b58bf18 100644
 -TARGET_C_PROPERTIES (H5detect STATIC " " " ")
 -if (MSVC OR MINGW)
 -  target_link_libraries (H5detect "ws2_32.lib")
--endif (MSVC OR MINGW)
+-endif ()
 -
 -set (CMD $<TARGET_FILE:H5detect>)
 -add_custom_command (
@@ -28,7 +28,7 @@ index 9fcb28d..b58bf18 100644
 -TARGET_C_PROPERTIES (H5make_libsettings STATIC " " " ")
 -if (MSVC OR MINGW)
 -  target_link_libraries (H5make_libsettings "ws2_32.lib")
--endif (MSVC OR MINGW)
+-endif ()
 -
 -set (CMD $<TARGET_FILE:H5make_libsettings>)
 -add_custom_command (

--- a/meta-refkit-extra/recipes-convnet/hdf5/hdf5_1.8.19.bb
+++ b/meta-refkit-extra/recipes-convnet/hdf5/hdf5_1.8.19.bb
@@ -20,8 +20,8 @@ SRC_URI = " \
     file://copy_generated.patch \
 "
 
-SRC_URI[md5sum] = "29117bf488887f89888f9304c8ebea0b"
-SRC_URI[sha256sum] = "01c6deadf4211f86922400da82c7a8b5b50dc8fc1ce0b5912de3066af316a48c"
+SRC_URI[md5sum] = "6f0353ee33e99089c110a1c8d2dd1b22"
+SRC_URI[sha256sum] = "59c03816105d57990329537ad1049ba22c2b8afe1890085f0c022b75f1727238"
 
 PACKAGES += "${PN}-extra"
 FILES_${PN} += "/usr/lib/libhdf5.settings"

--- a/meta-refkit-extra/recipes-convnet/lmdb/files/0001-Patch-the-main-Makefile.patch
+++ b/meta-refkit-extra/recipes-convnet/lmdb/files/0001-Patch-the-main-Makefile.patch
@@ -11,40 +11,44 @@ Taken from [1]
 
 Upstream-Status: Inappropriate [embedded specific]
 
+Signed-off-by: Ismo Puustinen <ismo.puustinen@intel.com>
+---
+ Makefile | 43 ++++++++++++++++++++++++-------------------
+ 1 file changed, 24 insertions(+), 19 deletions(-)
 
 diff --git a/Makefile b/Makefile
+index 72d0984..18d694a 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -24,25 +24,30 @@ OPT = -O2 -g
+@@ -26,6 +26,7 @@ OPT = -O2 -g
  CFLAGS	= $(THREADS) $(OPT) $(W) $(XCFLAGS)
  LDLIBS	=
  SOLIBS	=
 +SOVERSION = 0.0.0
+ SOEXT	= .so
  prefix	= /usr/local
-+binprefix = $(prefix)/bin                                                                     
-+libprefix = $(prefix)/lib              
-+includeprefix = $(prefix)/include
-+manprefix = $(prefix)/man
- 
+ exec_prefix = $(prefix)
+@@ -38,7 +39,7 @@ mandir = $(datarootdir)/man
  ########################################################################
  
  IHDRS	= lmdb.h
--ILIBS	= liblmdb.a liblmdb.so
-+ILIBS	= liblmdb.so liblmdb.so.$(SOVERSION)
+-ILIBS	= liblmdb.a liblmdb$(SOEXT)
++ILIBS	= liblmdb$(SOEXT) liblmdb$(SOEXT).$(SOVERSION)
  IPROGS	= mdb_stat mdb_copy mdb_dump mdb_load
  IDOCS	= mdb_stat.1 mdb_copy.1 mdb_dump.1 mdb_load.1
  PROGS	= $(IPROGS) mtest mtest2 mtest3 mtest4 mtest5
- all:	$(ILIBS) $(PROGS)
- 
- install: $(ILIBS) $(IPROGS) $(IHDRS)
--	for f in $(IPROGS); do cp $$f $(DESTDIR)$(prefix)/bin; done
--	for f in $(ILIBS); do cp $$f $(DESTDIR)$(prefix)/lib; done
--	for f in $(IHDRS); do cp $$f $(DESTDIR)$(prefix)/include; done
--	for f in $(IDOCS); do cp $$f $(DESTDIR)$(prefix)/man/man1; done
-+	for f in $(IPROGS); do cp $$f $(DESTDIR)$(binprefix); done
-+	for f in $(ILIBS); do cp -d $$f $(DESTDIR)$(libprefix); done
-+	for f in $(IHDRS); do cp $$f $(DESTDIR)$(includeprefix); done
-+	for f in $(IDOCS); do cp $$f $(DESTDIR)$(manprefix)/man1; done
+@@ -49,13 +50,13 @@ install: $(ILIBS) $(IPROGS) $(IHDRS)
+ 	mkdir -p $(DESTDIR)$(libdir)
+ 	mkdir -p $(DESTDIR)$(includedir)
+ 	mkdir -p $(DESTDIR)$(mandir)/man1
+-	for f in $(IPROGS); do cp $$f $(DESTDIR)$(bindir); done
+-	for f in $(ILIBS); do cp $$f $(DESTDIR)$(libdir); done
+-	for f in $(IHDRS); do cp $$f $(DESTDIR)$(includedir); done
+-	for f in $(IDOCS); do cp $$f $(DESTDIR)$(mandir)/man1; done
++	for f in $(IPROGS); do cp -a $$f $(DESTDIR)$(bindir); done
++	for f in $(ILIBS); do cp -a $$f $(DESTDIR)$(libdir); done
++	for f in $(IHDRS); do cp -a $$f $(DESTDIR)$(includedir); done
++	for f in $(IDOCS); do cp -a $$f $(DESTDIR)$(mandir)/man1; done
  
  clean:
 -	rm -rf $(PROGS) *.[ao] *.[ls]o *~ testdb
@@ -52,20 +56,19 @@ diff --git a/Makefile b/Makefile
  
  test:	all
  	rm -rf testdb && mkdir testdb
-@@ -51,20 +56,24 @@ test:	all
+@@ -64,20 +65,24 @@ test:	all
  liblmdb.a:	mdb.o midl.o
- 	ar rs $@ mdb.o midl.o
+ 	$(AR) rs $@ mdb.o midl.o
  
--liblmdb.so:	mdb.lo midl.lo
-+liblmdb.so:	liblmdb.so.$(SOVERSION)
+-liblmdb$(SOEXT):	mdb.lo midl.lo
++liblmdb$(SOEXT):	liblmdb$(SOEXT).$(SOVERSION)
 +	rm -f $@
 +	ln -s $< $@
 +
-+liblmdb.so.$(SOVERSION):	mdb.lo midl.lo
++liblmdb$(SOEXT).$(SOVERSION):	mdb.lo midl.lo
  #	$(CC) $(LDFLAGS) -pthread -shared -Wl,-Bsymbolic -o $@ mdb.o midl.o $(SOLIBS)
 -	$(CC) $(LDFLAGS) -pthread -shared -o $@ mdb.lo midl.lo $(SOLIBS)
-+	$(CC) $(LDFLAGS) -pthread -shared -Wl,-soname,$@ -o $@ mdb.lo midl.lo $(SOLIBS)
- 
+-
 -mdb_stat: mdb_stat.o liblmdb.a
 -mdb_copy: mdb_copy.o liblmdb.a
 -mdb_dump: mdb_dump.o liblmdb.a
@@ -76,6 +79,8 @@ diff --git a/Makefile b/Makefile
 -mtest4:	mtest4.o liblmdb.a
 -mtest5:	mtest5.o liblmdb.a
 -mtest6:	mtest6.o liblmdb.a
++	$(CC) $(LDFLAGS) -pthread -shared -Wl,-soname,$@ -o $@ mdb.lo midl.lo $(SOLIBS)
++
 +mdb_stat: mdb_stat.o liblmdb.so
 +mdb_copy: mdb_copy.o liblmdb.so
 +mdb_dump: mdb_dump.o liblmdb.so
@@ -89,3 +94,6 @@ diff --git a/Makefile b/Makefile
  
  mdb.o: mdb.c lmdb.h midl.h
  	$(CC) $(CFLAGS) $(CPPFLAGS) -c mdb.c
+-- 
+2.9.4
+

--- a/meta-refkit-extra/recipes-convnet/lmdb/lmdb_0.9.21.bb
+++ b/meta-refkit-extra/recipes-convnet/lmdb/lmdb_0.9.21.bb
@@ -7,8 +7,8 @@ SRC_URI = " \
     https://github.com/LMDB/lmdb/archive/LMDB_${PV}.tar.gz \
     file://0001-Patch-the-main-Makefile.patch \
 "
-SRC_URI[md5sum] = "0de89730b8f3f5711c2b3a4ba517b648"
-SRC_URI[sha256sum] = "49d7b40949f2ced9bc8b23ea6a89e75471a1c9126537a8b268c318a00b84322b"
+SRC_URI[md5sum] = "41a4f7b63212a00e53fabd8159008201"
+SRC_URI[sha256sum] = "1187b635a4cc415bb6972bba346121f81edd996e99b8f0816151d4090f90b559"
 
 inherit autotools-brokensep
 

--- a/meta-refkit-extra/recipes-convnet/python-imageio/python3-imageio_2.2.0.bb
+++ b/meta-refkit-extra/recipes-convnet/python-imageio/python3-imageio_2.2.0.bb
@@ -4,10 +4,10 @@ LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=295e673459dd7498500c971c98831367"
 
 SRC_URI = " \
-    https://github.com/imageio/imageio/archive/v${PV}.tar.gz \
+    https://github.com/imageio/imageio/archive/v${PV}.tar.gz;downloadfilename=${PN}-${PV}.tar.gz \
 "
-SRC_URI[md5sum] = "61bb19fa36d966c2dc85521948b338c9"
-SRC_URI[sha256sum] = "d7d411c25e2b46af99b6bbca7eb00cc9847981db12f467f6c8d9e7d7a80b277b"
+SRC_URI[md5sum] = "c375999eb6f96e9b7375940607d639ed"
+SRC_URI[sha256sum] = "086cf1f171d4307f488cf38c82e4cf191f8260e425112bfa825f746b75e98d60"
 
 S = "${WORKDIR}/imageio-${PV}"
 

--- a/meta-refkit-extra/recipes-convnet/python-pillow/python3-pillow_4.1.1.bb
+++ b/meta-refkit-extra/recipes-convnet/python-pillow/python3-pillow_4.1.1.bb
@@ -1,19 +1,19 @@
 SUMMARY = "Python library that provides an easy interface to read and write a wide range of image data, including animated images, video, volumetric data, and scientific formats."
 SECTION = "devel/python"
 LICENSE = "PIL"
-LIC_FILES_CHKSUM = "file://LICENSE;md5=ed22148166c9fd21895d7794dc16f6a5"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=fbbe34c5344f5c542baf8ef7621305d0"
 
 inherit setuptools3 pkgconfig distutils-tools
 
 SRC_URI = " \
-    https://github.com/python-pillow/Pillow/archive/${PV}a.tar.gz \
+    https://github.com/python-pillow/Pillow/archive/${PV}.tar.gz \
     file://0001-build-always-disable-platform-guessing.patch \
 "
 
-SRC_URI[md5sum] = "bca20cd48afd6618135540b34dba3267"
-SRC_URI[sha256sum] = "d498837f6c84d0fad9ef414dc0e9ee0b8d45d10efebc72898ed15950f111ad55"
+SRC_URI[md5sum] = "4889a8297f4068e339cbe8878db1834c"
+SRC_URI[sha256sum] = "606eca4a0801461e34d3bb4eb94df28fab5b3f6702eac8d1840d2da6a6d5d970"
 
-S = "${WORKDIR}/Pillow-${PV}a"
+S = "${WORKDIR}/Pillow-${PV}"
 
 DEPENDS += "python3 libjpeg-turbo zlib tiff freetype libpng jpeg"
 

--- a/meta-refkit-extra/recipes-convnet/python-protobuf/python3-protobuf_3.3.0.bb
+++ b/meta-refkit-extra/recipes-convnet/python-protobuf/python3-protobuf_3.3.0.bb
@@ -6,8 +6,8 @@ LIC_FILES_CHKSUM = "file://${WORKDIR}/git/LICENSE;md5=35953c752efc9299b184f91bef
 
 inherit setuptools3
 
-SRCREV = "a428e42072765993ff674fda72863c9f1aa2d268"
-PV = "3.1.0+git${SRCPV}"
+SRCREV = "a6189acd18b00611c1dc7042299ad75486f08a1a"
+PV = "3.3.0+git${SRCPV}"
 SRC_URI = "git://github.com/google/protobuf.git"
 
 S = "${WORKDIR}/git/python"


### PR DESCRIPTION
Updated versions for several components needed when using Caffe from Python. Cleaned also the Caffe recipe a bit, and reorganized example model sharing with OpenCV DNN. HDF5 was broken before this PR, because when the new version was released, the previous version was no longer available for download (at least from the same URL).