### PR TITLE
refkit-supported-recipes.txt: whitelist iwlwifi

### DIFF
--- a/meta-refkit/conf/distro/include/refkit-supported-recipes.txt
+++ b/meta-refkit/conf/distro/include/refkit-supported-recipes.txt
@@ -194,6 +194,7 @@ iptables-settings-default@refkit-core
 iptables@core
 iputils@core
 iso-codes@core
+iwlwifi@intel
 json-c@core
 json-glib@core
 kbd@core


### PR DESCRIPTION
Due to recent BSP changes, new package iwlwifi needs to be added
to the whitelist.

Signed-off-by: Jussi Laako <jussi.laako@linux.intel.com>