### PR TITLE
CI: expose daft error, stop storing licenses in PR case, support multiple mail recipient lists, misc.cleanup

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -162,7 +162,7 @@ try {
                     // data at nearly same time. Cover global summary add with same lock.
                     lock(resource: "global_data") {
                         summary += readFile "results-summary-${test_device}.${img}.log"
-                        archiveArtifacts allowEmptyArchive: true, artifacts: '*.log, *.xml'
+                        archiveArtifacts allowEmptyArchive: true, artifacts: '*.log, TEST-*.xml'
                         step_xunit('TEST-*.xml')
                     }
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,21 +16,16 @@
 
 def is_pr = env.JOB_NAME.endsWith("_pull-requests")
 def target_machine = "intel-corei7-64"
-
 // JOB_NAME expected to be in form <layer>_<branch>
 def current_project = "${env.JOB_NAME}".tokenize("_")[0]
 def image_name = "${current_project}_build:${env.BUILD_TAG}"
 def ci_build_id = "${env.BUILD_TIMESTAMP}-build-${env.BUILD_NUMBER}"
 def test_runs = [:]
-def testinfo_data = ""
-def ci_git_commit = ""
 def summary = ""
-def added_commits = ""
 def slot_name = "ci-"
 // reasonable value: keep few recent, dont take risk to fill disk
 int num_builds_to_keep = 4
 
-def ci_pr_num = ""
 if (is_pr) {
     if (params.containsKey("GITHUB_PR_NUMBER")) {
         ci_pr_num = "$GITHUB_PR_NUMBER"

--- a/docker/publish-project.sh
+++ b/docker/publish-project.sh
@@ -151,5 +151,4 @@ tar czf ${_tar_file} . \
         --exclude 'bitbake*.log*' --exclude 'build' --exclude 'build.pre' \
         --exclude 'buildhistory*' --exclude 'refkit_ci*' \
         --exclude '.git*' --exclude '*.testinfo.csv'
-rsync -av --chmod=F644 ${_tar_file} ${_RSYNC_DEST_BASE}/${JOB_NAME}-${CI_BUILD_ID}.tar.gz
-rm -f ${_tar_file}
+rsync -av --remove-source-files --chmod=F644 ${_tar_file} ${_RSYNC_DEST_BASE}/${JOB_NAME}-${CI_BUILD_ID}.tar.gz

--- a/docker/publish-project.sh
+++ b/docker/publish-project.sh
@@ -56,14 +56,13 @@ _RSYNC_DEST=${_RSYNC_DEST_BASE}/${_bresult_suffix}
 create_remote_dirs ${RSYNC_PUBLISH_DIR}/builds ${JOB_NAME}/${CI_BUILD_ID}
 # no uses for stored plain .wic files, skip storing on server, saving big part of space and transfer time
 [ -d ${_DEPL}/images ] && create_remote_dirs ${_RSYNC_DEST} images && rsync -avS --exclude '*.wic' ${_DEPL}/images/${TARGET_MACHINE} ${_RSYNC_DEST}/images/
-[ -d ${_DEPL}/licenses ] && create_remote_dirs ${_RSYNC_DEST} licenses && rsync -az --ignore-existing ${_DEPL}/licenses ${_RSYNC_DEST}/
+[ -d ${_DEPL}/licenses -a "$_jobtype" = "master" ] && create_remote_dirs ${_RSYNC_DEST} licenses && rsync -az --ignore-existing ${_DEPL}/licenses ${_RSYNC_DEST}/
 [ -d ${_DEPL}/sources ] && create_remote_dirs ${_RSYNC_DEST} sources && rsync -av --ignore-existing ${_DEPL}/sources ${_RSYNC_DEST}/
 [ -d ${_DEPL}/tools ] && create_remote_dirs ${_RSYNC_DEST} tools && rsync -av --ignore-existing ${_DEPL}/tools ${_RSYNC_DEST}/
 
 # If produced, publish swupd repo to build directory.
 # It will be published to real update location during build finalize steps
 if [ -d ${_DEPL}/swupd/${TARGET_MACHINE} ]; then
-    _jobtype=`echo ${JOB_NAME} | awk -F'_' '{print $NF}'`
     for s_dir in `find ${_DEPL}/swupd/${TARGET_MACHINE} -maxdepth 2 -name www -type d`; do
         i_dir=`dirname $s_dir`
         i_name=`basename $i_dir`
@@ -122,11 +121,13 @@ if [ -d ${_BRESULT}/work ]; then
 fi
 }
 
+# Start of script
 # Catch errors in pipelines
 set -o pipefail
 
 _RSYNC_DEST_BASE=${RSYNC_PUBLISH_DIR}/builds/${JOB_NAME}/${CI_BUILD_ID}
 _RSYNC_DEST_UPD=${RSYNC_PUBLISH_DIR}/updates
+_jobtype=`echo ${JOB_NAME} | awk -F'_' '{print $NF}'`
 
 cd $WORKSPACE/build
 for _bresult in `find . -maxdepth 1 -type d -name 'tmp-*glibc'`; do

--- a/docker/tester-exec.sh
+++ b/docker/tester-exec.sh
@@ -128,6 +128,13 @@ testimg() {
   # rename files to contain device and img_name
   rename TEST- TEST-${DEVICE}.${_IMG_NAME}. TEST-*.xml
   rename .log .${DEVICE}.${_IMG_NAME}.log *.log
+
+  # check for failure pattern and show containing file, to bring errors out
+  # in main job log instead of buried in one of many artifacts from DAFT.
+  if [ -f test_aft.${DEVICE}.${_IMG_NAME}.log -a -n "$(egrep -l 'FAIL|Traceback' test_aft.${DEVICE}.${_IMG_NAME}.log)" ]; then
+    echo "===== ERROR: failure reported in test_aft.${DEVICE}.${_IMG_NAME}.log ====="
+    cat test_aft.${DEVICE}.${_IMG_NAME}.log
+  fi
   ./tester-create-summary.sh "Image: ${FILENAME}" ${DEVICE} TEST-${DEVICE}.${_IMG_NAME} $num_masked > results-summary-${DEVICE}.${_IMG_NAME}.log
   set -e
 


### PR DESCRIPTION
1st commit:  narrow archived xml file set to TEST-*.xml in Jenkinsfile
Mask used to be *.xml causing over-archiving of results.xml
from every tester with latest one remaining in archive,
which was misleading as it appears different each time because it 
typicaly comes from different tests.
results.xml is not used for anything so leave it out.

2nd commit: : Check for failure pattern in daft log file in tester-exec and show containing file.
Show DAFT-stage errors in main level job log instead of explanation remaining buried in 
one of many artifacts from DAFT,  which needs locating and opening one-by-one in job artifacts area.
Note that same error is typically shown in results-runtest.*.log
and in test_aft.*.log, we show results-runtest*.log which is shorter.

3rd commit: rsync can remove sent file via cmd line option, can drop explicit rm command

4th commit: stop publishing licenses/ subdir in PR job
as not used for anything, just waste  of bandwidth and storage

5th commit: we can shorten Jenkinsfile, empty string vars dont need declaring if they
get value by assignment later

6th comment adds one level of indirection in mail recipients, allows to maintain 
different mail recipient sets fordifferent job variants
