### PR TITLE
librealsense_%.bbappend: remove x11 checking

### DIFF
--- a/meta-refkit-computervision/recipes-computervision/librealsense/librealsense_%.bbappend
+++ b/meta-refkit-computervision/recipes-computervision/librealsense/librealsense_%.bbappend
@@ -2,10 +2,10 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
 EXTRA_OECMAKE_df-refkit-computervision = " \
        -DBUILD_SHARED_LIBS:BOOL=ON -DBUILD_UNIT_TESTS:BOOL=OFF -DBUILD_EXAMPLES:BOOL=ON \
-       -DBUILD_GRAPHICAL_EXAMPLES:BOOL=${@bb.utils.contains('DISTRO_FEATURES', 'x11 opengl', 'ON', 'OFF', d)} \
+       -DBUILD_GRAPHICAL_EXAMPLES:BOOL=${@bb.utils.contains('DISTRO_FEATURES', 'opengl opengl-native', 'ON', 'OFF', d)} \
 "
  
-PACKAGES_df-refkit-computervision = "${PN} ${PN}-dbg ${PN}-dev ${PN}-examples ${@bb.utils.contains('DISTRO_FEATURES', 'x11 opengl', '${PN}-graphical-examples', '', d)}"
+PACKAGES_df-refkit-computervision = "${PN} ${PN}-dbg ${PN}-dev ${PN}-examples ${@bb.utils.contains('DISTRO_FEATURES', 'opengl opengl-native', '${PN}-graphical-examples', '', d)}"
 
 SRC_URI_append_df-refkit-computervision = " \
     file://0001-scripts-removed-bashisms.patch \


### PR DESCRIPTION
Require librealsense example and tutorial application be to install inside development image target.
In order to test librealsense on meta-iotqa.