### PR TITLE
Remove pulseaudio rdepending on console kit

### DIFF
--- a/meta-refkit-core/bbappends/openembedded-core/meta/recipes-multimedia/pulseaudio/pulseaudio_%.bbappend
+++ b/meta-refkit-core/bbappends/openembedded-core/meta/recipes-multimedia/pulseaudio/pulseaudio_%.bbappend
@@ -1,2 +1,3 @@
 DEPENDS_remove_df-refkit-config = "gconf"
 EXTRA_OECONF_append_df-refkit-config = " --disable-gconf"
+RDEPENDS_${PN}-module-console-kit_remove_df-refkit-config = "consolekit"


### PR DESCRIPTION
Remove consolekit run time dependency, because refkit is not
using it anyway. We are using systemd/logind which makes
consolekit obsolete.

Signed-off-by: Jaska Uimonen <jaska.uimonen@intel.com>