### PR TITLE
refkit-config.inc: Fix apache 2.0 linking with GPL license issue.

### DIFF
--- a/meta-refkit-core/conf/distro/include/refkit-config.inc
+++ b/meta-refkit-core/conf/distro/include/refkit-config.inc
@@ -156,5 +156,9 @@ PACKAGECONFIG_append_pn-opencv_df-refkit-config = " opencl dnn"
 PACKAGECONFIG_remove_pn-connman_df-refkit-config = "iptables"
 PACKAGECONFIG_append_pn-connman_df-refkit-config = " nftables"
 
+# Use ssl instead of gnutls
+PACKAGECONFIG_remove_pn-curl_df-refkit-config = "gnutls"
+PACKAGECONFIG_append_pn-curl_df-refkit-config = " ssl"
+
 #remove gtk dependency from opencv
 PACKAGECONFIG_remove_pn-opencv_df-refkit-config = "gtk"


### PR DESCRIPTION
In order to work with Secure Boot requirement, reduce the need for (L)GPLv3 components.
This is done by recompiling components with different configuration parameters,
reducing functionality, and leaving components out from the production images

[REFKIT #11494]

Signed-off-by: Choong Yin Thong <yin.thong.choong@intel.com>