### PR TITLE
refkit: move to meta-clang pyro branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -27,7 +27,7 @@
 [submodule "meta-clang"]
 	path = meta-clang
 	url = https://github.com/kraj/meta-clang.git
-	branch = master
+	branch = pyro
 [submodule "meta-security"]
 	path = meta-security
 	url = https://git.yoctoproject.org/git/meta-security


### PR DESCRIPTION
meta-clang master moved to clang 5.0 release branch but
beignet fails to build with it so move to use meta-clang
pyro branch that has 4.0.

Signed-off-by: Mikko Ylinen <mikko.ylinen@linux.intel.com>