### PR TITLE
CI Jenkinsfile: need ci_pr_num declared in master build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,6 +27,7 @@ def slot_name = "ci-"
 // reasonable value: keep few recent, dont take risk to fill disk
 int num_builds_to_keep = 4
 
+def ci_pr_num = ""
 if (is_pr) {
     if (params.containsKey("GITHUB_PR_NUMBER")) {
         ci_pr_num = "$GITHUB_PR_NUMBER"


### PR DESCRIPTION
Recent reduction of predefined variables was verified in PR
build only, and slipped through a regression failing master
build in CI where ci_pr_num does not get value and thus
remains undefined variable.

Signed-off-by: Olev Kartau <olev.kartau@intel.com>