### PR TITLE
supported-recipes: add openssl10

### DIFF
--- a/meta-refkit/conf/distro/include/refkit-supported-recipes.txt
+++ b/meta-refkit/conf/distro/include/refkit-supported-recipes.txt
@@ -342,6 +342,7 @@ opencl-headers@refkit-computervision
 opencv@openembedded-layer
 openjdk-8@meta-java
 openssh@core
+openssl10@core
 openssl@core
 opkg-utils@core
 orc@core


### PR DESCRIPTION
openembedded-core (currently in master-next) moved to openssl 1.1 but added
openssl10 recipe for backwards compatibility (some recipes, like openssh,
need it).

Add the new openssl10 recipe in supported recipes to be able build it.

Signed-off-by: Mikko Ylinen <mikko.ylinen@linux.intel.com>