### PR TITLE
CI : Fix attempt to egrep missing file, avoid publisher error on missing sdk/*.sh

### DIFF
--- a/docker/publish-project.sh
+++ b/docker/publish-project.sh
@@ -78,9 +78,9 @@ if [ -d ${_DEPL}/swupd/${TARGET_MACHINE} ]; then
 fi
 
 if [ -d ${_DEPL}/sdk ]; then
-    # publish installer .sh file to sdk/
+    # publish installer .sh file(s), if any exist, to sdk/
     create_remote_dirs ${_RSYNC_DEST} sdk/${TARGET_MACHINE}
-    rsync -av ${_DEPL}/sdk/*.sh ${_RSYNC_DEST}/sdk/${TARGET_MACHINE}/
+    rsync -av --ignore-missing-args ${_DEPL}/sdk/*.sh ${_RSYNC_DEST}/sdk/${TARGET_MACHINE}/
 fi
 if [ -d ${_DEPL}/sdk-data/${TARGET_MACHINE} ]; then
     # publish sdk-data/ without -v option, avoiding logging massive list

--- a/docker/tester-exec.sh
+++ b/docker/tester-exec.sh
@@ -131,9 +131,11 @@ testimg() {
 
   # check for failure pattern and show containing file, to bring errors out
   # in main job log instead of buried in one of many artifacts from DAFT.
-  if [ -f test_aft.${DEVICE}.${_IMG_NAME}.log -a -n "$(egrep -l 'FAIL|Traceback' test_aft.${DEVICE}.${_IMG_NAME}.log)" ]; then
-    echo "===== ERROR: failure reported in test_aft.${DEVICE}.${_IMG_NAME}.log ====="
-    cat test_aft.${DEVICE}.${_IMG_NAME}.log
+  if [ -f test_aft.${DEVICE}.${_IMG_NAME}.log ]; then
+    if [ -n "$(egrep -l 'FAIL|Traceback' test_aft.${DEVICE}.${_IMG_NAME}.log)" ]; then
+      echo "===== ERROR: failure reported in test_aft.${DEVICE}.${_IMG_NAME}.log ====="
+      cat test_aft.${DEVICE}.${_IMG_NAME}.log
+    fi
   fi
   ./tester-create-summary.sh "Image: ${FILENAME}" ${DEVICE} TEST-${DEVICE}.${_IMG_NAME} $num_masked > results-summary-${DEVICE}.${_IMG_NAME}.log
   set -e


### PR DESCRIPTION
1st commit:
Recent addition about exposing traceback in main log
created problem where egrep was tried on missing file
in qemu tester case. Shell AND-ed operators are not
performed by left-to-right logic, commands are attempted first.

2nd commit avoids publisher error in case of missing sdk/*.sh
which can happen in certain build failure case.
