### PR TITLE
Experimental: Use bb server timeout

### DIFF
--- a/meta-refkit/conf/distro/include/refkit-ci.inc
+++ b/meta-refkit/conf/distro/include/refkit-ci.inc
@@ -109,6 +109,9 @@ REFKIT_CI_TEST_RUNS=" \
 # space checks on (possibly remote, like NFS) volumes.
 BB_DISKMON_DIRS = ""
 
+# Bitbake server timeout, for series of invocations to use same server
+BB_SERVER_TIMEOUT = "5"
+
 #
 # Dymamic section.
 # Values are applied dynamically based on runtime config or builder host


### PR DESCRIPTION
CI env: set BB_SERVER_TIMEOUT=5 for series of bitbake

NOTE: hopefully not needed, idea is that builds should work without it.
    
    During CI build there are now 26 bitbake invocations,
    and we see races involving old server exiting while a new BB
    trying to reconnect. Keeping server around for few seconds
    should help with those.