### PR TITLE
CI publish-project.sh: adjust tar options to exclude correctly

### DIFF
--- a/docker/publish-project.sh
+++ b/docker/publish-project.sh
@@ -147,9 +147,9 @@ rsync -lv latest ${_RSYNC_DEST_BASE}/../
 # create clean tarball of source, leaving out .git* and parts created by build and test stages
 cd $WORKSPACE
 _tar_file=`mktemp --suffix=.tar.gz`
-tar czf ${_tar_file} . \
-        --transform "s,^\.,${JOB_NAME}-${CI_BUILD_ID},S" \
-        --exclude 'bitbake*.log*' --exclude 'build' --exclude 'build.pre' \
-        --exclude 'buildhistory*' --exclude 'refkit_ci*' \
-        --exclude '.git*' --exclude '*.testinfo.csv'
+tar --transform "s,^\.,${JOB_NAME}-${CI_BUILD_ID},S" \
+    --exclude=bitbake*.log* --exclude=build* \
+    --exclude=buildhistory* --exclude=refkit_ci* \
+    --exclude=.git* --exclude=*.testinfo.csv \
+    -czf ${_tar_file} .
 rsync -av --remove-source-files --chmod=F644 ${_tar_file} ${_RSYNC_DEST_BASE}/${JOB_NAME}-${CI_BUILD_ID}.tar.gz


### PR DESCRIPTION
It appears with new tar 1.29 on Ubuntu 17.04,
build/ and others end up included in source archive.
Adjust tar options to work with older and newer tar versions.

Signed-off-by: Olev Kartau <olev.kartau@intel.com>