### PR TITLE
refkit: use libmnl from @core layer

### DIFF
--- a/meta-refkit/conf/distro/include/refkit-supported-recipes.txt
+++ b/meta-refkit/conf/distro/include/refkit-supported-recipes.txt
@@ -239,7 +239,7 @@ libinput@core
 libjpeg-turbo@core
 libksba@core
 libmicrohttpd@soletta
-libmnl@networking-layer
+libmnl@core
 libmpc@core
 libnftnl@networking-layer
 libnl@core

--- a/meta-refkit/conf/distro/refkit.conf
+++ b/meta-refkit/conf/distro/refkit.conf
@@ -183,6 +183,7 @@ INHERIT += "supported-recipes"
 # want to take from the layer that normally would be chosen.
 BBMASK += " \
     meta-oe/recipes-graphics/xorg-driver/xf86-video-mga \
+    meta-networking/recipes-filter/libmnl \
     meta-intel/common/recipes-core/ovmf \
 "
 


### PR DESCRIPTION
libmnl recipe from meta-networking was moved to OE-core while
fixing some Yocto Compliance checker issues.

Modify supported-recipes.txt to adapt to that change.

Signed-off-by: Mikko Ylinen <mikko.ylinen@linux.intel.com>