### PR TITLE
meta-iotqa: upsquared.mask

### DIFF
--- a/meta-iotqa/conf/test/upsquared.mask
+++ b/meta-iotqa/conf/test/upsquared.mask
@@ -1,0 +1,3 @@
+#this file contains tests which cant be run on Upsquared
+oeqa.runtime.sanity.comm_wifi_connect
+oeqa.runtime.sanity.comm_btcheck


### PR DESCRIPTION
Ignores tests for UP Squared that cannot be run on it.

Jenkins uses mask files to determine the DAFT tests that are to be excluded for each supported board. UP Squared doesn't have Bluetooth and WIFI so it makes sense to exclude these tests to avoid unnecessary error notifications which would appear with every pull request test.

Signed-off-by: Sami Nieminen <sami1.nieminen@intel.com>