### PR TITLE
Remove ovmf secure boot patch

### DIFF
--- a/meta-refkit/conf/distro/refkit.conf
+++ b/meta-refkit/conf/distro/refkit.conf
@@ -184,7 +184,7 @@ INHERIT += "supported-recipes"
 BBMASK += " \
     meta-oe/recipes-graphics/xorg-driver/xf86-video-mga \
     meta-networking/recipes-filter/libmnl \
-    meta-intel/common/recipes-core/ovmf \
+    meta-intel/recipes-core/ovmf \
 "
 
 # IoT Reference OS Kit removes certain packages from images because the components are known


### PR DESCRIPTION
ovmf UEFI secure boot patch is now provided by upstream meta-intel,
not needed in refkit anymore.

Signed-off-by: Jussi Laako <jussi.laako@linux.intel.com>