### PR TITLE
TPM: support also tpm2-tools 3.0

### DIFF
--- a/meta-refkit-core/recipes-images/images/refkit-installer-image.bb
+++ b/meta-refkit-core/recipes-images/images/refkit-installer-image.bb
@@ -99,7 +99,9 @@ REFKIT_INSTALLER_UEFI_COMBO () {
                         fatal "key creation failed"
                     fi
                     keyfile_offset="${REFKIT_DISK_ENCRYPTION_NVRAM_ID_LEN}"
-                    if ! execute tpm2_nvwrite -x "${REFKIT_DISK_ENCRYPTION_NVRAM_INDEX_TPM2}" -a 0x40000001 -f "$keyfile"; then
+                    # -f is only used by the older release
+                    if (tpm2_nvwrite -v | grep -q "version 2.1" && ! execute tpm2_nvwrite -x "${REFKIT_DISK_ENCRYPTION_NVRAM_INDEX_TPM2}" -a 0x40000001 -f "$keyfile" ) ||
+                       ! execute tpm2_nvwrite -x "${REFKIT_DISK_ENCRYPTION_NVRAM_INDEX_TPM2}" -a 0x40000001 "$keyfile"; then
                         fatal "storing key in NVRAM failed"
                     fi
                     # Lock access until reboot.


### PR DESCRIPTION
The upcoming release changes the commands a bit. Some preparations for
that had been made already, but they were untested and indeed
incomplete.

For now the goal is to support the old stable branch and the new
one. Later the invocations for 1.2 can be removed.

This can be tested by updating meta-measured to https://github.com/pohly/meta-measured/tree/tpm2-tools-3.0